### PR TITLE
docs: clarify bunny-game live runtime architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ Each baby bunny has five essential needs that both players must manage:
 - **Mobile-first**: Touch-optimized responsive design
 - **Graphics**: Programmatically drawn cute sprites
 
+### Current deployment model
+- **Live web entrypoint**: `bunny-backend` serves both the API and the static frontend
+- **Current production shape**: backend + PostgreSQL + Redis
+- **Separate frontend pod**: not required in the current production architecture
+- **Architecture notes**: see `docs/DEPLOYMENT-ARCHITECTURE.md`
+
 ### Key Features
 - **Real-time Multiplayer**: All actions sync instantly between players
 - **Mobile Optimized**: Perfect for couples playing on their phones

--- a/docs/DEPLOYMENT-ARCHITECTURE.md
+++ b/docs/DEPLOYMENT-ARCHITECTURE.md
@@ -1,0 +1,32 @@
+# Bunny Game Deployment Architecture
+
+## Current production architecture
+
+The current Kubernetes deployment is a **single web entrypoint** architecture:
+
+- `bunny-backend` serves the Express API
+- `bunny-backend` also serves the static frontend from `frontend/`
+- `bunny-postgres` stores persistent game data
+- `bunny-redis` supports runtime/state features
+
+That means **a separate `bunny-frontend` pod/service is not required in the current live setup**.
+
+## Why issue #7 happened
+
+The repository still contains standalone `k8s/frontend-*.yaml` manifests from an older or alternate split-frontend idea. Those files make it look like a frontend Deployment should exist in production, but the live cluster currently serves the game through `bunny-backend` instead.
+
+## Live validation notes
+
+The expected live checks for the current architecture are:
+
+- `bunny-backend` Deployment is healthy
+- `bunny-backend` Service is reachable
+- `GET /` returns the Bunny Family HTML app shell
+- `GET /health` returns healthy status
+- frontend assets such as `game.js` and Socket.IO client references are present in the served page
+
+## Guidance going forward
+
+- Treat `bunny-backend` as the canonical public web entrypoint for the current deployment model.
+- Do **not** assume a missing frontend pod is an outage by itself.
+- If the project later moves to a split frontend/backend architecture, that should be handled as an explicit architecture change and approved/planned separately.

--- a/k8s/frontend-deployment.yaml
+++ b/k8s/frontend-deployment.yaml
@@ -1,3 +1,6 @@
+# NOTE: This standalone frontend manifest is not part of the current production architecture.
+# Production currently serves the static frontend from bunny-backend.
+# See docs/DEPLOYMENT-ARCHITECTURE.md before applying split-frontend resources.
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/k8s/frontend-hpa.yaml
+++ b/k8s/frontend-hpa.yaml
@@ -1,3 +1,6 @@
+# NOTE: This standalone frontend manifest is not part of the current production architecture.
+# Production currently serves the static frontend from bunny-backend.
+# See docs/DEPLOYMENT-ARCHITECTURE.md before applying split-frontend resources.
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/k8s/frontend-service.yaml
+++ b/k8s/frontend-service.yaml
@@ -1,3 +1,6 @@
+# NOTE: This standalone frontend manifest is not part of the current production architecture.
+# Production currently serves the static frontend from bunny-backend.
+# See docs/DEPLOYMENT-ARCHITECTURE.md before applying split-frontend resources.
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
## Summary
Fixes issue #7 by aligning the repo with the actual live Kubernetes/runtime architecture.

## What changed
- documented the current single-entrypoint production architecture
- clarified in the README that `bunny-backend` serves both the API and static frontend
- marked standalone `k8s/frontend-*` manifests as non-production/split-frontend resources to avoid false outage assumptions

## Live validation
- `kubectl get all -n bunny-game` shows healthy `bunny-backend`, `bunny-postgres`, and `bunny-redis`
- no live `bunny-frontend` Deployment/Service exists
- `curl http://172.20.10.114/` returns the Bunny Family HTML app shell
- `curl http://172.20.10.114/health` returns healthy status

## Result
The issue was not a live frontend outage. It was repo/runtime drift and missing architecture documentation.
