### PR TITLE
Use uploaded sleeping bunny asset

### DIFF
--- a/frontend/assets/bunnies/baby-bunny-sleeping.svg
+++ b/frontend/assets/bunnies/baby-bunny-sleeping.svg
@@ -1,0 +1,78 @@
+<svg width="120" height="120" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Left Ear (slightly droopy) -->
+  <ellipse cx="40" cy="30" rx="10" ry="25" fill="#B4E7FF" transform="rotate(-20 40 30)" stroke="#99DEFF" stroke-width="0.5"/>
+  <ellipse cx="40" cy="32" rx="5" ry="18" fill="#ff69b4" transform="rotate(-20 40 32)" opacity="0.6"/>
+
+  <!-- Right Ear (slightly droopy) -->
+  <ellipse cx="80" cy="30" rx="10" ry="25" fill="#B4E7FF" transform="rotate(20 80 30)" stroke="#99DEFF" stroke-width="0.5"/>
+  <ellipse cx="80" cy="32" rx="5" ry="18" fill="#ff69b4" transform="rotate(20 80 32)" opacity="0.6"/>
+
+  <!-- Head -->
+  <circle cx="60" cy="54" r="27" fill="#B4E7FF" stroke="#99DEFF" stroke-width="0.5"/>
+
+  <!-- Fur fluff on head (extra fluffy) -->
+  <circle cx="45" cy="45" r="5" fill="#D9F2FF" opacity="0.8"/>
+  <circle cx="75" cy="45" r="5" fill="#D9F2FF" opacity="0.8"/>
+  <circle cx="51" cy="39" r="4" fill="#D9F2FF" opacity="0.7"/>
+  <circle cx="69" cy="39" r="4" fill="#D9F2FF" opacity="0.7"/>
+  <circle cx="60" cy="36" r="3" fill="#D9F2FF" opacity="0.6"/>
+
+  <!-- Closed eyes (peaceful) -->
+  <path d="M 45 51 Q 51 53 57 51" stroke="#1a1a1a" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+  <path d="M 63 51 Q 69 53 75 51" stroke="#1a1a1a" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+
+  <!-- Eyelashes -->
+  <path d="M 45 50 L 43 48" stroke="#1a1a1a" stroke-width="1" fill="none" stroke-linecap="round"/>
+  <path d="M 57 50 L 59 48" stroke="#1a1a1a" stroke-width="1" fill="none" stroke-linecap="round"/>
+  <path d="M 63 50 L 61 48" stroke="#1a1a1a" stroke-width="1" fill="none" stroke-linecap="round"/>
+  <path d="M 75 50 L 77 48" stroke="#1a1a1a" stroke-width="1" fill="none" stroke-linecap="round"/>
+
+  <!-- Soft Blush -->
+  <ellipse cx="42" cy="57" rx="7" ry="4" fill="#ff69b4" opacity="0.3"/>
+  <ellipse cx="78" cy="57" rx="7" ry="4" fill="#ff69b4" opacity="0.3"/>
+
+  <!-- Nose -->
+  <ellipse cx="60" cy="60" rx="3" ry="2.5" fill="#ff69b4"/>
+
+  <!-- Whiskers - Left side (relaxed) -->
+  <line x1="39" y1="59" x2="21" y2="59" stroke="#99DEFF" stroke-width="1.5" stroke-linecap="round" opacity="0.7"/>
+  <line x1="39" y1="61" x2="21" y2="62" stroke="#99DEFF" stroke-width="1.5" stroke-linecap="round" opacity="0.7"/>
+  <line x1="41" y1="60" x2="24" y2="60" stroke="#99DEFF" stroke-width="1.5" stroke-linecap="round" opacity="0.7"/>
+
+  <!-- Whiskers - Right side (relaxed) -->
+  <line x1="81" y1="59" x2="99" y2="59" stroke="#99DEFF" stroke-width="1.5" stroke-linecap="round" opacity="0.7"/>
+  <line x1="81" y1="61" x2="99" y2="62" stroke="#99DEFF" stroke-width="1.5" stroke-linecap="round" opacity="0.7"/>
+  <line x1="79" y1="60" x2="96" y2="60" stroke="#99DEFF" stroke-width="1.5" stroke-linecap="round" opacity="0.7"/>
+
+  <!-- Peaceful tiny smile -->
+  <path d="M 55 64 Q 60 66 65 64" stroke="#1a1a1a" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+
+  <!-- Body (curled up) -->
+  <ellipse cx="60" cy="87" rx="24" ry="27" fill="#B4E7FF" stroke="#99DEFF" stroke-width="0.5"/>
+
+  <!-- Extra fur fluff on body (cozy) -->
+  <circle cx="45" cy="81" r="6" fill="#D9F2FF" opacity="0.8"/>
+  <circle cx="75" cy="81" r="6" fill="#D9F2FF" opacity="0.8"/>
+  <circle cx="48" cy="93" r="5" fill="#D9F2FF" opacity="0.7"/>
+  <circle cx="72" cy="93" r="5" fill="#D9F2FF" opacity="0.7"/>
+  <circle cx="60" cy="75" r="4" fill="#D9F2FF" opacity="0.6"/>
+
+  <!-- Left Paw (tucked) -->
+  <ellipse cx="45" cy="105" rx="7" ry="9" fill="#B4E7FF" stroke="#99DEFF" stroke-width="0.5"/>
+  <circle cx="45" cy="112" r="4" fill="#D9F2FF"/>
+
+  <!-- Right Paw (tucked) -->
+  <ellipse cx="75" cy="105" rx="7" ry="9" fill="#B4E7FF" stroke="#99DEFF" stroke-width="0.5"/>
+  <circle cx="75" cy="112" r="4" fill="#D9F2FF"/>
+
+  <!-- Fluffy Tail (wrapped around) -->
+  <circle cx="84" cy="93" r="10" fill="#B4E7FF" stroke="#99DEFF" stroke-width="0.5"/>
+  <circle cx="87" cy="90" r="8" fill="#D9F2FF" opacity="0.9"/>
+  <circle cx="89" cy="93" r="7" fill="#D9F2FF" opacity="0.8"/>
+  <circle cx="87" cy="96" r="6" fill="#D9F2FF" opacity="0.7"/>
+
+  <!-- Zzz sleep symbols -->
+  <text x="85" y="25" font-family="Arial" font-size="10" fill="#8B7DBD" opacity="0.6">Z</text>
+  <text x="92" y="20" font-family="Arial" font-size="8" fill="#8B7DBD" opacity="0.5">z</text>
+  <text x="97" y="16" font-family="Arial" font-size="6" fill="#8B7DBD" opacity="0.4">z</text>
+</svg>

--- a/frontend/src/objects/Bunny.ts
+++ b/frontend/src/objects/Bunny.ts
@@ -19,6 +19,7 @@ export class Bunny extends Phaser.GameObjects.Container {
   private rightArm: Phaser.GameObjects.Ellipse;
   private tail: Phaser.GameObjects.Ellipse;
   private belly: Phaser.GameObjects.Ellipse;
+  private sleepingAsset: Phaser.GameObjects.Image | null = null;
 
   public bunnyId: string;
   public bunnyName: string;
@@ -223,8 +224,29 @@ export class Bunny extends Phaser.GameObjects.Container {
   playSleeping() {
     this.stopAnim();
     this.animState = 'sleeping';
-    this.leftEye.setScale(1, 0.15);
-    this.rightEye.setScale(1, 0.15);
+
+    if (this.scene.textures.exists('baby-bunny-sleeping') && this.stage !== 'egg') {
+      this.setDrawnBodyVisible(false);
+      const s = this.getStageScale();
+      this.sleepingAsset = this.scene.add.image(0, -2 * s, 'baby-bunny-sleeping');
+      this.sleepingAsset.setDisplaySize(96 * s, 96 * s);
+      this.sleepingAsset.setDepth(2);
+      this.add(this.sleepingAsset);
+
+      this.scene.tweens.add({
+        targets: this.sleepingAsset,
+        scaleX: this.sleepingAsset.scaleX * 1.03,
+        scaleY: this.sleepingAsset.scaleY * 1.03,
+        duration: 1300,
+        yoyo: true,
+        repeat: -1,
+        ease: 'Sine.easeInOut',
+      });
+    } else {
+      this.leftEye.setScale(1, 0.15);
+      this.rightEye.setScale(1, 0.15);
+    }
+
     this.zzz = this.scene.add.text(30, -60, '💤', { fontSize: '22px' });
     this.add(this.zzz);
     this.scene.tweens.add({
@@ -280,9 +302,15 @@ export class Bunny extends Phaser.GameObjects.Container {
   stopAnim() {
     if (this.bounceTimer) { this.bounceTimer.destroy(); this.bounceTimer = null; }
     if (this.zzz) { this.zzz.destroy(); this.zzz = null; }
+    if (this.sleepingAsset) {
+      this.scene.tweens.killTweensOf(this.sleepingAsset);
+      this.sleepingAsset.destroy();
+      this.sleepingAsset = null;
+    }
     this.scene.tweens.killTweensOf(this);
     this.scene.tweens.killTweensOf(this.leftEar);
     this.scene.tweens.killTweensOf(this.rightEar);
+    this.setDrawnBodyVisible(true);
     this.leftEye.setScale(1, 1);
     this.rightEye.setScale(1, 1);
     this.mouth.setAngle(0);
@@ -292,6 +320,14 @@ export class Bunny extends Phaser.GameObjects.Container {
     this.setScale(1);
     const tint = BUNNY_COLORS[this.color] || 0xfff5ee;
     this.bodyShape.setFillStyle(tint);
+  }
+
+  private setDrawnBodyVisible(visible: boolean) {
+    this.list.forEach(child => {
+      if (child !== this.nameLabel && child !== this.zzz && child !== this.sleepingAsset) {
+        (child as Phaser.GameObjects.GameObject & { setVisible?: (value: boolean) => void }).setVisible?.(visible);
+      }
+    });
   }
 
   setInteractable(onClick: () => void) {

--- a/frontend/src/scenes/BootScene.ts
+++ b/frontend/src/scenes/BootScene.ts
@@ -4,6 +4,13 @@ import { GAME_WIDTH, GAME_HEIGHT, COLORS } from '../config';
 export class BootScene extends Phaser.Scene {
   constructor() { super({ key: 'BootScene' }); }
 
+  preload() {
+    this.load.svg('baby-bunny-sleeping', '/assets/bunnies/baby-bunny-sleeping.svg', {
+      width: 120,
+      height: 120,
+    });
+  }
+
   create() {
     const cx = GAME_WIDTH / 2;
     const cy = GAME_HEIGHT / 2;


### PR DESCRIPTION
## Summary
- Adds the uploaded sleeping baby bunny SVG as a canonical frontend asset.
- Preloads it in the Phaser boot scene.
- Uses it during sleeping bunny animations, while keeping the existing drawn bunny as fallback for non-sleeping states and missing texture cases.

## Validation
- `cd frontend && npm ci && npm run build`
- Build succeeded. Vite reported the existing large chunk warning.
- npm audit reports 3 moderate vulnerabilities in existing dependencies.

Closes #17.