### PR TITLE
Fix uploaded bunny assets visibility

### DIFF
--- a/frontend/assets/bunnies/adult-bunny.svg
+++ b/frontend/assets/bunnies/adult-bunny.svg
@@ -1,0 +1,79 @@
+<svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Left Ear -->
+  <ellipse cx="70" cy="45" rx="18" ry="45" fill="#B4E7FF" transform="rotate(-15 70 45)" stroke="#99DEFF" stroke-width="1"/>
+  <ellipse cx="70" cy="48" rx="10" ry="35" fill="#ff69b4" transform="rotate(-15 70 48)" opacity="0.6"/>
+
+  <!-- Right Ear -->
+  <ellipse cx="130" cy="45" rx="18" ry="45" fill="#B4E7FF" transform="rotate(15 130 45)" stroke="#99DEFF" stroke-width="1"/>
+  <ellipse cx="130" cy="48" rx="10" ry="35" fill="#ff69b4" transform="rotate(15 130 48)" opacity="0.6"/>
+
+  <!-- Head -->
+  <circle cx="100" cy="90" r="45" fill="#B4E7FF" stroke="#99DEFF" stroke-width="1"/>
+
+  <!-- Fur fluff on head -->
+  <circle cx="75" cy="75" r="8" fill="#D9F2FF" opacity="0.6"/>
+  <circle cx="125" cy="75" r="8" fill="#D9F2FF" opacity="0.6"/>
+  <circle cx="85" cy="65" r="6" fill="#D9F2FF" opacity="0.5"/>
+  <circle cx="115" cy="65" r="6" fill="#D9F2FF" opacity="0.5"/>
+
+  <!-- Eyes -->
+  <ellipse cx="85" cy="85" rx="12" ry="15" fill="white"/>
+  <ellipse cx="115" cy="85" rx="12" ry="15" fill="white"/>
+
+  <!-- Pupils -->
+  <circle cx="87" cy="88" r="8" fill="#1a1a1a"/>
+  <circle cx="117" cy="88" r="8" fill="#1a1a1a"/>
+
+  <!-- Eye shine -->
+  <circle cx="84" cy="83" r="4" fill="white"/>
+  <circle cx="114" cy="83" r="4" fill="white"/>
+  <circle cx="90" cy="91" r="2" fill="white" opacity="0.7"/>
+  <circle cx="120" cy="91" r="2" fill="white" opacity="0.7"/>
+
+  <!-- Blush -->
+  <ellipse cx="70" cy="95" rx="10" ry="7" fill="#ff69b4" opacity="0.4"/>
+  <ellipse cx="130" cy="95" rx="10" ry="7" fill="#ff69b4" opacity="0.4"/>
+
+  <!-- Nose -->
+  <ellipse cx="100" cy="100" rx="5" ry="4" fill="#ff69b4"/>
+
+  <!-- Whiskers - Left side -->
+  <line x1="65" y1="98" x2="35" y2="95" stroke="#99DEFF" stroke-width="2" stroke-linecap="round"/>
+  <line x1="65" y1="102" x2="35" y2="105" stroke="#99DEFF" stroke-width="2" stroke-linecap="round"/>
+  <line x1="68" y1="100" x2="40" y2="100" stroke="#99DEFF" stroke-width="2" stroke-linecap="round"/>
+
+  <!-- Whiskers - Right side -->
+  <line x1="135" y1="98" x2="165" y2="95" stroke="#99DEFF" stroke-width="2" stroke-linecap="round"/>
+  <line x1="135" y1="102" x2="165" y2="105" stroke="#99DEFF" stroke-width="2" stroke-linecap="round"/>
+  <line x1="132" y1="100" x2="160" y2="100" stroke="#99DEFF" stroke-width="2" stroke-linecap="round"/>
+
+  <!-- Mouth -->
+  <path d="M 100 100 Q 95 105 90 103" stroke="#1a1a1a" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M 100 100 Q 105 105 110 103" stroke="#1a1a1a" stroke-width="2" fill="none" stroke-linecap="round"/>
+
+  <!-- Body -->
+  <ellipse cx="100" cy="145" rx="40" ry="45" fill="#B4E7FF" stroke="#99DEFF" stroke-width="1"/>
+
+  <!-- Fur fluff on body -->
+  <circle cx="75" cy="135" r="10" fill="#D9F2FF" opacity="0.6"/>
+  <circle cx="125" cy="135" r="10" fill="#D9F2FF" opacity="0.6"/>
+  <circle cx="80" cy="155" r="8" fill="#D9F2FF" opacity="0.5"/>
+  <circle cx="120" cy="155" r="8" fill="#D9F2FF" opacity="0.5"/>
+  <circle cx="90" cy="170" r="6" fill="#D9F2FF" opacity="0.4"/>
+  <circle cx="110" cy="170" r="6" fill="#D9F2FF" opacity="0.4"/>
+
+  <!-- Left Paw -->
+  <ellipse cx="75" cy="175" rx="12" ry="15" fill="#B4E7FF" stroke="#99DEFF" stroke-width="1"/>
+  <circle cx="75" cy="187" r="7" fill="#D9F2FF"/>
+
+  <!-- Right Paw -->
+  <ellipse cx="125" cy="175" rx="12" ry="15" fill="#B4E7FF" stroke="#99DEFF" stroke-width="1"/>
+  <circle cx="125" cy="187" r="7" fill="#D9F2FF"/>
+
+  <!-- Fluffy Tail -->
+  <circle cx="140" cy="155" r="15" fill="#B4E7FF" stroke="#99DEFF" stroke-width="1"/>
+  <circle cx="145" cy="150" r="12" fill="#D9F2FF" opacity="0.7"/>
+  <circle cx="148" cy="155" r="10" fill="#D9F2FF" opacity="0.6"/>
+  <circle cx="145" cy="160" r="8" fill="#D9F2FF" opacity="0.5"/>
+  <circle cx="142" cy="148" r="7" fill="#D9F2FF" opacity="0.4"/>
+</svg>

--- a/frontend/assets/bunnies/baby-bunny-happy.svg
+++ b/frontend/assets/bunnies/baby-bunny-happy.svg
@@ -1,0 +1,76 @@
+<svg width="120" height="120" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Left Ear -->
+  <ellipse cx="42" cy="27" rx="10" ry="25" fill="#B4E7FF" transform="rotate(-15 42 27)" stroke="#99DEFF" stroke-width="0.5"/>
+  <ellipse cx="42" cy="29" rx="5" ry="18" fill="#ff69b4" transform="rotate(-15 42 29)" opacity="0.6"/>
+
+  <!-- Right Ear -->
+  <ellipse cx="78" cy="27" rx="10" ry="25" fill="#B4E7FF" transform="rotate(15 78 27)" stroke="#99DEFF" stroke-width="0.5"/>
+  <ellipse cx="78" cy="29" rx="5" ry="18" fill="#ff69b4" transform="rotate(15 78 29)" opacity="0.6"/>
+
+  <!-- Head -->
+  <circle cx="60" cy="54" r="27" fill="#B4E7FF" stroke="#99DEFF" stroke-width="0.5"/>
+
+  <!-- Fur fluff on head -->
+  <circle cx="45" cy="45" r="4" fill="#D9F2FF" opacity="0.8"/>
+  <circle cx="75" cy="45" r="4" fill="#D9F2FF" opacity="0.8"/>
+  <circle cx="51" cy="39" r="3" fill="#D9F2FF" opacity="0.7"/>
+  <circle cx="69" cy="39" r="3" fill="#D9F2FF" opacity="0.7"/>
+
+  <!-- Happy closed eyes (curved upward) -->
+  <path d="M 45 50 Q 51 47 57 50" stroke="#1a1a1a" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+  <path d="M 63 50 Q 69 47 75 50" stroke="#1a1a1a" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+
+  <!-- Eye shine sparkles -->
+  <circle cx="48" cy="48" r="1.5" fill="white" opacity="0.9"/>
+  <circle cx="72" cy="48" r="1.5" fill="white" opacity="0.9"/>
+
+  <!-- Rosy Blush (bigger for happy) -->
+  <ellipse cx="40" cy="57" rx="8" ry="5" fill="#ff69b4" opacity="0.5"/>
+  <ellipse cx="80" cy="57" rx="8" ry="5" fill="#ff69b4" opacity="0.5"/>
+
+  <!-- Nose -->
+  <ellipse cx="60" cy="59" rx="3" ry="2.5" fill="#ff69b4"/>
+
+  <!-- Whiskers - Left side -->
+  <line x1="39" y1="58" x2="21" y2="56" stroke="#99DEFF" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="39" y1="60" x2="21" y2="62" stroke="#99DEFF" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="41" y1="59" x2="24" y2="59" stroke="#99DEFF" stroke-width="1.5" stroke-linecap="round"/>
+
+  <!-- Whiskers - Right side -->
+  <line x1="81" y1="58" x2="99" y2="56" stroke="#99DEFF" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="81" y1="60" x2="99" y2="62" stroke="#99DEFF" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="79" y1="59" x2="96" y2="59" stroke="#99DEFF" stroke-width="1.5" stroke-linecap="round"/>
+
+  <!-- Big Happy Smile -->
+  <path d="M 50 62 Q 60 70 70 62" stroke="#1a1a1a" stroke-width="2" fill="none" stroke-linecap="round"/>
+
+  <!-- Smile dimples -->
+  <circle cx="48" cy="63" r="1.5" fill="#ff69b4" opacity="0.3"/>
+  <circle cx="72" cy="63" r="1.5" fill="#ff69b4" opacity="0.3"/>
+
+  <!-- Body -->
+  <ellipse cx="60" cy="87" rx="24" ry="27" fill="#B4E7FF" stroke="#99DEFF" stroke-width="0.5"/>
+
+  <!-- Fur fluff on body -->
+  <circle cx="45" cy="81" r="5" fill="#D9F2FF" opacity="0.8"/>
+  <circle cx="75" cy="81" r="5" fill="#D9F2FF" opacity="0.8"/>
+  <circle cx="48" cy="93" r="4" fill="#D9F2FF" opacity="0.7"/>
+  <circle cx="72" cy="93" r="4" fill="#D9F2FF" opacity="0.7"/>
+
+  <!-- Left Paw -->
+  <ellipse cx="45" cy="105" rx="7" ry="9" fill="#B4E7FF" stroke="#99DEFF" stroke-width="0.5"/>
+  <circle cx="45" cy="112" r="4" fill="#D9F2FF"/>
+
+  <!-- Right Paw -->
+  <ellipse cx="75" cy="105" rx="7" ry="9" fill="#B4E7FF" stroke="#99DEFF" stroke-width="0.5"/>
+  <circle cx="75" cy="112" r="4" fill="#D9F2FF"/>
+
+  <!-- Fluffy Tail -->
+  <circle cx="84" cy="93" r="9" fill="#B4E7FF" stroke="#99DEFF" stroke-width="0.5"/>
+  <circle cx="87" cy="90" r="7" fill="#D9F2FF" opacity="0.9"/>
+  <circle cx="89" cy="93" r="6" fill="#D9F2FF" opacity="0.8"/>
+  <circle cx="87" cy="96" r="5" fill="#D9F2FF" opacity="0.7"/>
+
+  <!-- Heart sparkle (happy) -->
+  <path d="M 60 35 L 61 37 L 63 37 L 61.5 38.5 L 62 40 L 60 39 L 58 40 L 58.5 38.5 L 57 37 L 59 37 Z" fill="#ff69b4" opacity="0.6"/>
+</svg>

--- a/frontend/assets/bunnies/baby-bunny-normal.svg
+++ b/frontend/assets/bunnies/baby-bunny-normal.svg
@@ -1,0 +1,76 @@
+<svg width="120" height="120" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Left Ear -->
+  <ellipse cx="42" cy="27" rx="10" ry="25" fill="#B4E7FF" transform="rotate(-15 42 27)" stroke="#99DEFF" stroke-width="0.5"/>
+  <ellipse cx="42" cy="29" rx="5" ry="18" fill="#ff69b4" transform="rotate(-15 42 29)" opacity="0.6"/>
+
+  <!-- Right Ear -->
+  <ellipse cx="78" cy="27" rx="10" ry="25" fill="#B4E7FF" transform="rotate(15 78 27)" stroke="#99DEFF" stroke-width="0.5"/>
+  <ellipse cx="78" cy="29" rx="5" ry="18" fill="#ff69b4" transform="rotate(15 78 29)" opacity="0.6"/>
+
+  <!-- Head -->
+  <circle cx="60" cy="54" r="27" fill="#B4E7FF" stroke="#99DEFF" stroke-width="0.5"/>
+
+  <!-- Fur fluff on head -->
+  <circle cx="45" cy="45" r="4" fill="#D9F2FF" opacity="0.6"/>
+  <circle cx="75" cy="45" r="4" fill="#D9F2FF" opacity="0.6"/>
+  <circle cx="51" cy="39" r="3" fill="#D9F2FF" opacity="0.5"/>
+  <circle cx="69" cy="39" r="3" fill="#D9F2FF" opacity="0.5"/>
+
+  <!-- Eyes -->
+  <ellipse cx="51" cy="51" rx="7" ry="9" fill="white"/>
+  <ellipse cx="69" cy="51" rx="7" ry="9" fill="white"/>
+
+  <!-- Pupils -->
+  <circle cx="52" cy="53" r="5" fill="#1a1a1a"/>
+  <circle cx="70" cy="53" r="5" fill="#1a1a1a"/>
+
+  <!-- Eye shine -->
+  <circle cx="50" cy="50" r="2.5" fill="white"/>
+  <circle cx="68" cy="50" r="2.5" fill="white"/>
+  <circle cx="54" cy="55" r="1.5" fill="white" opacity="0.7"/>
+  <circle cx="72" cy="55" r="1.5" fill="white" opacity="0.7"/>
+
+  <!-- Blush -->
+  <ellipse cx="42" cy="57" rx="6" ry="4" fill="#ff69b4" opacity="0.4"/>
+  <ellipse cx="78" cy="57" rx="6" ry="4" fill="#ff69b4" opacity="0.4"/>
+
+  <!-- Nose -->
+  <ellipse cx="60" cy="60" rx="3" ry="2.5" fill="#ff69b4"/>
+
+  <!-- Whiskers - Left side -->
+  <line x1="39" y1="59" x2="21" y2="57" stroke="#99DEFF" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="39" y1="61" x2="21" y2="63" stroke="#99DEFF" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="41" y1="60" x2="24" y2="60" stroke="#99DEFF" stroke-width="1.5" stroke-linecap="round"/>
+
+  <!-- Whiskers - Right side -->
+  <line x1="81" y1="59" x2="99" y2="57" stroke="#99DEFF" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="81" y1="61" x2="99" y2="63" stroke="#99DEFF" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="79" y1="60" x2="96" y2="60" stroke="#99DEFF" stroke-width="1.5" stroke-linecap="round"/>
+
+  <!-- Mouth -->
+  <path d="M 60 60 Q 57 63 54 62" stroke="#1a1a1a" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M 60 60 Q 63 63 66 62" stroke="#1a1a1a" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+
+  <!-- Body -->
+  <ellipse cx="60" cy="87" rx="24" ry="27" fill="#B4E7FF" stroke="#99DEFF" stroke-width="0.5"/>
+
+  <!-- Fur fluff on body -->
+  <circle cx="45" cy="81" r="5" fill="#D9F2FF" opacity="0.6"/>
+  <circle cx="75" cy="81" r="5" fill="#D9F2FF" opacity="0.6"/>
+  <circle cx="48" cy="93" r="4" fill="#D9F2FF" opacity="0.5"/>
+  <circle cx="72" cy="93" r="4" fill="#D9F2FF" opacity="0.5"/>
+
+  <!-- Left Paw -->
+  <ellipse cx="45" cy="105" rx="7" ry="9" fill="#B4E7FF" stroke="#99DEFF" stroke-width="0.5"/>
+  <circle cx="45" cy="112" r="4" fill="#D9F2FF"/>
+
+  <!-- Right Paw -->
+  <ellipse cx="75" cy="105" rx="7" ry="9" fill="#B4E7FF" stroke="#99DEFF" stroke-width="0.5"/>
+  <circle cx="75" cy="112" r="4" fill="#D9F2FF"/>
+
+  <!-- Fluffy Tail -->
+  <circle cx="84" cy="93" r="9" fill="#B4E7FF" stroke="#99DEFF" stroke-width="0.5"/>
+  <circle cx="87" cy="90" r="7" fill="#D9F2FF" opacity="0.7"/>
+  <circle cx="89" cy="93" r="6" fill="#D9F2FF" opacity="0.6"/>
+  <circle cx="87" cy="96" r="5" fill="#D9F2FF" opacity="0.5"/>
+</svg>

--- a/frontend/src/objects/Bunny.ts
+++ b/frontend/src/objects/Bunny.ts
@@ -19,7 +19,7 @@ export class Bunny extends Phaser.GameObjects.Container {
   private rightArm: Phaser.GameObjects.Ellipse;
   private tail: Phaser.GameObjects.Ellipse;
   private belly: Phaser.GameObjects.Ellipse;
-  private sleepingAsset: Phaser.GameObjects.Image | null = null;
+  private spriteAsset: Phaser.GameObjects.Image | null = null;
 
   public bunnyId: string;
   public bunnyName: string;
@@ -184,9 +184,40 @@ export class Bunny extends Phaser.GameObjects.Container {
     }
   }
 
+  private getIdleAssetKey(): string | null {
+    if (this.stage === 'egg') return null;
+    if (this.stage === 'adult' || this.stage === 'elder') return 'adult-bunny';
+    return 'baby-bunny-normal';
+  }
+
+  private getAssetDisplaySize(assetKey: string, scale: number): number {
+    return assetKey === 'adult-bunny' ? 128 * scale : 96 * scale;
+  }
+
+  private showSpriteAsset(assetKey: string, yOffset = -2) {
+    if (!this.scene.textures.exists(assetKey) || this.stage === 'egg') return false;
+
+    if (this.spriteAsset) {
+      this.scene.tweens.killTweensOf(this.spriteAsset);
+      this.spriteAsset.destroy();
+      this.spriteAsset = null;
+    }
+
+    this.setDrawnBodyVisible(false);
+    const s = this.getStageScale();
+    this.spriteAsset = this.scene.add.image(0, yOffset * s, assetKey);
+    const size = this.getAssetDisplaySize(assetKey, s);
+    this.spriteAsset.setDisplaySize(size, size);
+    this.spriteAsset.setDepth(2);
+    this.add(this.spriteAsset);
+    return true;
+  }
+
   startIdleBounce() {
     this.animState = 'idle';
     this.stopAnim();
+    const idleAsset = this.getIdleAssetKey();
+    if (idleAsset) this.showSpriteAsset(idleAsset);
     this.bounceTimer = this.scene.time.addEvent({
       delay: 1200,
       loop: true,
@@ -205,6 +236,7 @@ export class Bunny extends Phaser.GameObjects.Container {
   playEating() {
     this.stopAnim();
     this.animState = 'eating';
+    this.showSpriteAsset(this.stage === 'adult' || this.stage === 'elder' ? 'adult-bunny' : 'baby-bunny-happy');
     this.bounceTimer = this.scene.time.addEvent({
       delay: 300,
       loop: true,
@@ -225,23 +257,19 @@ export class Bunny extends Phaser.GameObjects.Container {
     this.stopAnim();
     this.animState = 'sleeping';
 
-    if (this.scene.textures.exists('baby-bunny-sleeping') && this.stage !== 'egg') {
-      this.setDrawnBodyVisible(false);
-      const s = this.getStageScale();
-      this.sleepingAsset = this.scene.add.image(0, -2 * s, 'baby-bunny-sleeping');
-      this.sleepingAsset.setDisplaySize(96 * s, 96 * s);
-      this.sleepingAsset.setDepth(2);
-      this.add(this.sleepingAsset);
-
-      this.scene.tweens.add({
-        targets: this.sleepingAsset,
-        scaleX: this.sleepingAsset.scaleX * 1.03,
-        scaleY: this.sleepingAsset.scaleY * 1.03,
-        duration: 1300,
-        yoyo: true,
-        repeat: -1,
-        ease: 'Sine.easeInOut',
-      });
+    if (this.showSpriteAsset(this.stage === 'adult' || this.stage === 'elder' ? 'adult-bunny' : 'baby-bunny-sleeping')) {
+      const spriteAsset = this.spriteAsset;
+      if (spriteAsset) {
+        this.scene.tweens.add({
+          targets: spriteAsset,
+          scaleX: spriteAsset.scaleX * 1.03,
+          scaleY: spriteAsset.scaleY * 1.03,
+          duration: 1300,
+          yoyo: true,
+          repeat: -1,
+          ease: 'Sine.easeInOut',
+        });
+      }
     } else {
       this.leftEye.setScale(1, 0.15);
       this.rightEye.setScale(1, 0.15);
@@ -262,6 +290,7 @@ export class Bunny extends Phaser.GameObjects.Container {
   playPlaying() {
     this.stopAnim();
     this.animState = 'playing';
+    this.showSpriteAsset(this.stage === 'adult' || this.stage === 'elder' ? 'adult-bunny' : 'baby-bunny-happy');
     this.bounceTimer = this.scene.time.addEvent({
       delay: 500,
       loop: true,
@@ -302,10 +331,10 @@ export class Bunny extends Phaser.GameObjects.Container {
   stopAnim() {
     if (this.bounceTimer) { this.bounceTimer.destroy(); this.bounceTimer = null; }
     if (this.zzz) { this.zzz.destroy(); this.zzz = null; }
-    if (this.sleepingAsset) {
-      this.scene.tweens.killTweensOf(this.sleepingAsset);
-      this.sleepingAsset.destroy();
-      this.sleepingAsset = null;
+    if (this.spriteAsset) {
+      this.scene.tweens.killTweensOf(this.spriteAsset);
+      this.spriteAsset.destroy();
+      this.spriteAsset = null;
     }
     this.scene.tweens.killTweensOf(this);
     this.scene.tweens.killTweensOf(this.leftEar);
@@ -324,7 +353,7 @@ export class Bunny extends Phaser.GameObjects.Container {
 
   private setDrawnBodyVisible(visible: boolean) {
     this.list.forEach(child => {
-      if (child !== this.nameLabel && child !== this.zzz && child !== this.sleepingAsset) {
+      if (child !== this.nameLabel && child !== this.zzz && child !== this.spriteAsset) {
         (child as Phaser.GameObjects.GameObject & { setVisible?: (value: boolean) => void }).setVisible?.(visible);
       }
     });

--- a/frontend/src/scenes/BootScene.ts
+++ b/frontend/src/scenes/BootScene.ts
@@ -5,9 +5,18 @@ export class BootScene extends Phaser.Scene {
   constructor() { super({ key: 'BootScene' }); }
 
   preload() {
-    this.load.svg('baby-bunny-sleeping', '/assets/bunnies/baby-bunny-sleeping.svg', {
-      width: 120,
-      height: 120,
+    const bunnyAssets = [
+      { key: 'baby-bunny-normal', path: '/assets/bunnies/baby-bunny-normal.svg', size: 120 },
+      { key: 'baby-bunny-happy', path: '/assets/bunnies/baby-bunny-happy.svg', size: 120 },
+      { key: 'baby-bunny-sleeping', path: '/assets/bunnies/baby-bunny-sleeping.svg', size: 120 },
+      { key: 'adult-bunny', path: '/assets/bunnies/adult-bunny.svg', size: 160 },
+    ];
+
+    bunnyAssets.forEach(({ key, path, size }) => {
+      this.load.svg(key, path, {
+        width: size,
+        height: size,
+      });
     });
   }
 


### PR DESCRIPTION
## Summary
- Add canonical uploaded SVG assets for baby normal, baby happy, and adult bunny categories
- Preload all visible bunny asset states in the Phaser boot scene
- Render uploaded SVG sprites for idle/normal, happy/eating/playing, sleeping, and adult/elder bunnies instead of only the drawn primitive bunny

Fixes #19.

## Validation
- npm --prefix frontend install --no-audit --no-fund
- npm --prefix frontend run build

## Deploy note
Live deploy/verification is still blocked from this runner while the home-lab route to 192.168.1.106 / 172.20.10.30 / 172.20.10.114 is unreachable.