### PR TITLE
Fix #23: Collapsible side stats HUD

### DIFF
--- a/frontend/src/scenes/HUDScene.ts
+++ b/frontend/src/scenes/HUDScene.ts
@@ -1,14 +1,17 @@
 import Phaser from 'phaser';
-import { GAME_WIDTH, GAME_HEIGHT, COLORS } from '../config';
+import { GAME_WIDTH, COLORS } from '../config';
 import { StatBar } from '../objects/StatBar';
 import { ActionButton } from '../objects/ActionButton';
-import { gameBunnies, selectedBunnyId, activityLog, setSelectedBunny } from './RoomScene';
-import { wsClient, type BunnyState } from '../network/WebSocketClient';
+import { gameBunnies, selectedBunnyId } from './RoomScene';
 import { toggleMute, isMuted } from '../utils/sound';
 import { ACTION_COOLDOWNS, CARE_ACTIONS, type CareAction } from '../game/actions';
 
-const TOOLBAR_HEIGHT = 120;
-const PANEL_Y = GAME_HEIGHT - TOOLBAR_HEIGHT;
+const HUD_PREF_KEY = 'bunny:hud-expanded';
+const SIDE_PANEL_WIDTH = 184;
+const SIDE_PANEL_MARGIN = 12;
+const COMPACT_PANEL_WIDTH = 58;
+const MOBILE_BREAKPOINT = 700;
+const PLAY_AREA_HEIGHT = 480;
 
 export class HUDScene extends Phaser.Scene {
   private statBars: { hunger: StatBar; happiness: StatBar; cleanliness: StatBar; energy: StatBar; health: StatBar } | null = null;
@@ -17,92 +20,26 @@ export class HUDScene extends Phaser.Scene {
   private roomLabel!: Phaser.GameObjects.Text;
   private actionButtons = new Map<CareAction, ActionButton>();
   private cooldownUntil = new Map<CareAction, number>();
+  private panel!: Phaser.GameObjects.Container;
+  private panelBg!: Phaser.GameObjects.Rectangle;
+  private toggleBtn!: Phaser.GameObjects.Text;
+  private compactSummary!: Phaser.GameObjects.Text;
+  private expandedContent!: Phaser.GameObjects.Container;
+  private hudExpanded = true;
+  private isMobile = false;
 
   constructor() { super({ key: 'HUDScene' }); }
 
   create() {
-    // Semi-transparent bottom toolbar panel
-    const panelBg = this.add.rectangle(GAME_WIDTH / 2, PANEL_Y + TOOLBAR_HEIGHT / 2, GAME_WIDTH, TOOLBAR_HEIGHT, 0x1a1a2e, 0.92);
-    panelBg.setDepth(0);
+    this.isMobile = this.scale.width < MOBILE_BREAKPOINT;
+    this.hudExpanded = this.loadHudPreference();
 
-    // Top border gradient line
-    this.add.rectangle(GAME_WIDTH / 2, PANEL_Y, GAME_WIDTH, 2, 0xff6b9d, 0.7);
+    this.createSidePanel();
+    this.createNavigation();
+    this.createRoomLabel();
 
-    // Left section: bunny info + stats
-    this.bunnyNameText = this.add.text(12, PANEL_Y + 8, 'Select a bunny', {
-      fontFamily: 'Arial, sans-serif',
-      fontSize: '12px',
-      color: '#ff6b9d',
-      fontStyle: 'bold',
-    });
+    this.scale.on('resize', () => this.layoutPanel());
 
-    const barX = 8;
-    const barY = PANEL_Y + 28;
-    this.statBars = {
-      hunger: new StatBar(this, barX, barY, '🍳 HGR', COLORS.hunger, 90),
-      happiness: new StatBar(this, barX, barY + 16, '😊 HAP', COLORS.happiness, 90),
-      cleanliness: new StatBar(this, barX + 155, barY, '🛁 CLN', COLORS.cleanliness, 90),
-      energy: new StatBar(this, barX + 155, barY + 16, '⚡ NRG', COLORS.energy, 90),
-      health: new StatBar(this, barX + 310, barY, '❤️ HP', COLORS.health, 90),
-    };
-
-    // Action buttons row with visible client-side cooldowns.
-    const actionColors: Record<CareAction, number> = {
-      feed: COLORS.btnFeed,
-      clean: COLORS.btnClean,
-      play: COLORS.btnPlay,
-      sleep: COLORS.btnSleep,
-      medicine: COLORS.btnMedicine,
-      breed: COLORS.btnBreed,
-    };
-    const btnY = PANEL_Y + 88;
-    const btnSpacing = GAME_WIDTH / (CARE_ACTIONS.length + 1);
-    CARE_ACTIONS.forEach((a, i) => {
-      const btn = new ActionButton(this, btnSpacing * (i + 1), btnY, a.label, actionColors[a.action], () => {
-        this.doRoomAction(a.action);
-      }, 110, 36);
-      this.actionButtons.set(a.action, btn);
-    });
-
-    // Navigation arrows (above toolbar, on left/right edges)
-    const rooms = ['LivingRoomScene', 'KitchenScene', 'BathroomScene', 'GardenScene', 'BedroomScene', 'VetScene', 'NestScene'];
-    const arrowY = (PANEL_Y) / 2;
-
-    const leftArrow = this.add.text(18, arrowY, '◀', {
-      fontSize: '32px', color: '#ffffff', stroke: '#333', strokeThickness: 3,
-    }).setOrigin(0.5).setInteractive({ useHandCursor: true }).setAlpha(0.7);
-
-    const rightArrow = this.add.text(GAME_WIDTH - 18, arrowY, '▶', {
-      fontSize: '32px', color: '#ffffff', stroke: '#333', strokeThickness: 3,
-    }).setOrigin(0.5).setInteractive({ useHandCursor: true }).setAlpha(0.7);
-
-    leftArrow.on('pointerover', () => leftArrow.setAlpha(1));
-    leftArrow.on('pointerout', () => leftArrow.setAlpha(0.7));
-    rightArrow.on('pointerover', () => rightArrow.setAlpha(1));
-    rightArrow.on('pointerout', () => rightArrow.setAlpha(0.7));
-    leftArrow.on('pointerdown', () => this.navigateRoom(-1, rooms));
-    rightArrow.on('pointerdown', () => this.navigateRoom(1, rooms));
-
-    // Mute button
-    this.muteBtn = this.add.text(GAME_WIDTH - 30, PANEL_Y + 8, isMuted() ? '🔇' : '🔊', {
-      fontSize: '18px',
-    }).setOrigin(0.5).setInteractive({ useHandCursor: true });
-    this.muteBtn.on('pointerdown', () => {
-      const m = toggleMute();
-      this.muteBtn.setText(m ? '🔇' : '🔊');
-    });
-
-    // Room name label at top
-    this.roomLabel = this.add.text(GAME_WIDTH / 2, 12, '', {
-      fontFamily: 'Arial, sans-serif',
-      fontSize: '16px',
-      color: '#ffffff',
-      stroke: '#333333',
-      strokeThickness: 3,
-      fontStyle: 'bold',
-    }).setOrigin(0.5);
-
-    // Update loop
     this.time.addEvent({
       delay: 400,
       loop: true,
@@ -113,20 +50,165 @@ export class HUDScene extends Phaser.Scene {
     });
   }
 
+  private loadHudPreference(): boolean {
+    const saved = window.localStorage.getItem(HUD_PREF_KEY);
+    if (saved === 'expanded') return true;
+    if (saved === 'collapsed') return false;
+    return this.scale.width >= MOBILE_BREAKPOINT;
+  }
+
+  private saveHudPreference() {
+    window.localStorage.setItem(HUD_PREF_KEY, this.hudExpanded ? 'expanded' : 'collapsed');
+  }
+
+  private createSidePanel() {
+    this.panel = this.add.container(0, 0).setDepth(50);
+    this.panelBg = this.add.rectangle(0, 0, SIDE_PANEL_WIDTH, PLAY_AREA_HEIGHT - 24, 0x1a1a2e, 0.9)
+      .setOrigin(0, 0)
+      .setStrokeStyle(2, COLORS.accent, 0.55);
+    this.panel.add(this.panelBg);
+
+    this.toggleBtn = this.add.text(0, 0, '', {
+      fontFamily: 'Arial, sans-serif',
+      fontSize: '15px',
+      color: '#ffffff',
+      backgroundColor: '#ff6b9d',
+      padding: { x: 8, y: 5 },
+      fontStyle: 'bold',
+    }).setOrigin(1, 0).setInteractive({ useHandCursor: true });
+    this.toggleBtn.on('pointerdown', () => {
+      this.hudExpanded = !this.hudExpanded;
+      this.saveHudPreference();
+      this.layoutPanel();
+    });
+    this.panel.add(this.toggleBtn);
+
+    this.compactSummary = this.add.text(0, 0, '🐰\n--', {
+      fontFamily: 'Arial, sans-serif',
+      fontSize: '12px',
+      color: '#ffffff',
+      align: 'center',
+      lineSpacing: 7,
+    }).setOrigin(0.5, 0);
+    this.panel.add(this.compactSummary);
+
+    this.expandedContent = this.add.container(0, 0);
+    this.panel.add(this.expandedContent);
+
+    this.bunnyNameText = this.add.text(12, 14, 'Select a bunny', {
+      fontFamily: 'Arial, sans-serif',
+      fontSize: '13px',
+      color: '#ff6b9d',
+      fontStyle: 'bold',
+      wordWrap: { width: SIDE_PANEL_WIDTH - 34 },
+    });
+    this.expandedContent.add(this.bunnyNameText);
+
+    const barX = 12;
+    const barY = 52;
+    this.statBars = {
+      hunger: new StatBar(this, barX, barY, '🍳 Hunger', COLORS.hunger, 92),
+      happiness: new StatBar(this, barX, barY + 24, '😊 Happy', COLORS.happiness, 92),
+      cleanliness: new StatBar(this, barX, barY + 48, '🛁 Clean', COLORS.cleanliness, 92),
+      energy: new StatBar(this, barX, barY + 72, '⚡ Energy', COLORS.energy, 92),
+      health: new StatBar(this, barX, barY + 96, '❤️ Health', COLORS.health, 92),
+    };
+    Object.values(this.statBars).forEach(bar => this.expandedContent.add(bar));
+
+    const actionColors: Record<CareAction, number> = {
+      feed: COLORS.btnFeed,
+      clean: COLORS.btnClean,
+      play: COLORS.btnPlay,
+      sleep: COLORS.btnSleep,
+      medicine: COLORS.btnMedicine,
+      breed: COLORS.btnBreed,
+    };
+    CARE_ACTIONS.forEach((a, i) => {
+      const x = i % 2 === 0 ? 55 : 134;
+      const y = 210 + Math.floor(i / 2) * 42;
+      const btn = new ActionButton(this, x, y, a.label, actionColors[a.action], () => {
+        this.doRoomAction(a.action);
+      }, 70, 32);
+      this.actionButtons.set(a.action, btn);
+      this.expandedContent.add(btn);
+    });
+
+    this.muteBtn = this.add.text(SIDE_PANEL_WIDTH - 22, PLAY_AREA_HEIGHT - 62, isMuted() ? '🔇' : '🔊', {
+      fontSize: '18px',
+    }).setOrigin(0.5).setInteractive({ useHandCursor: true });
+    this.muteBtn.on('pointerdown', () => {
+      const muted = toggleMute();
+      this.muteBtn.setText(muted ? '🔇' : '🔊');
+    });
+    this.expandedContent.add(this.muteBtn);
+
+    this.layoutPanel();
+  }
+
+  private layoutPanel() {
+    this.isMobile = this.scale.width < MOBILE_BREAKPOINT;
+    const width = this.hudExpanded ? SIDE_PANEL_WIDTH : COMPACT_PANEL_WIDTH;
+    const height = this.hudExpanded ? PLAY_AREA_HEIGHT - 24 : 116;
+    const x = GAME_WIDTH - width - SIDE_PANEL_MARGIN;
+    const y = this.isMobile && !this.hudExpanded ? SIDE_PANEL_MARGIN + 38 : SIDE_PANEL_MARGIN;
+
+    this.panel.setPosition(x, y);
+    this.panelBg.setSize(width, height);
+    this.panelBg.setAlpha(this.hudExpanded ? 0.9 : 0.82);
+    this.toggleBtn.setPosition(width - 8, 8);
+    this.toggleBtn.setText(this.hudExpanded ? '›' : '‹');
+    this.compactSummary.setPosition(width / 2, 38);
+    this.compactSummary.setVisible(!this.hudExpanded);
+    this.expandedContent.setVisible(this.hudExpanded);
+  }
+
+  private createNavigation() {
+    const rooms = ['LivingRoomScene', 'KitchenScene', 'BathroomScene', 'GardenScene', 'BedroomScene', 'VetScene', 'NestScene'];
+    const arrowY = PLAY_AREA_HEIGHT / 2;
+
+    const leftArrow = this.add.text(18, arrowY, '◀', {
+      fontSize: '32px', color: '#ffffff', stroke: '#333', strokeThickness: 3,
+    }).setOrigin(0.5).setInteractive({ useHandCursor: true }).setAlpha(0.7).setDepth(40);
+
+    const rightArrow = this.add.text(GAME_WIDTH - 18, arrowY, '▶', {
+      fontSize: '32px', color: '#ffffff', stroke: '#333', strokeThickness: 3,
+    }).setOrigin(0.5).setInteractive({ useHandCursor: true }).setAlpha(0.7).setDepth(40);
+
+    leftArrow.on('pointerover', () => leftArrow.setAlpha(1));
+    leftArrow.on('pointerout', () => leftArrow.setAlpha(0.7));
+    rightArrow.on('pointerover', () => rightArrow.setAlpha(1));
+    rightArrow.on('pointerout', () => rightArrow.setAlpha(0.7));
+    leftArrow.on('pointerdown', () => this.navigateRoom(-1, rooms));
+    rightArrow.on('pointerdown', () => this.navigateRoom(1, rooms));
+  }
+
+  private createRoomLabel() {
+    this.roomLabel = this.add.text(GAME_WIDTH / 2, 12, '', {
+      fontFamily: 'Arial, sans-serif',
+      fontSize: '16px',
+      color: '#ffffff',
+      stroke: '#333333',
+      strokeThickness: 3,
+      fontStyle: 'bold',
+    }).setOrigin(0.5).setDepth(40);
+  }
+
   private updateHUD() {
     const bunny = gameBunnies.find(b => b.id === selectedBunnyId) || gameBunnies.find(b => b.isAlive);
     if (bunny && this.statBars) {
-      this.bunnyNameText.setText(`🐰 ${bunny.name} [${bunny.stage}]`);
+      this.bunnyNameText.setText(`🐰 ${bunny.name}\n${bunny.stage}`);
       this.statBars.hunger.setValue(bunny.hunger);
       this.statBars.happiness.setValue(bunny.happiness);
       this.statBars.cleanliness.setValue(bunny.cleanliness);
       this.statBars.energy.setValue(bunny.energy);
       this.statBars.health.setValue(bunny.health);
+      const lowest = Math.min(bunny.hunger, bunny.happiness, bunny.cleanliness, bunny.energy, bunny.health);
+      this.compactSummary.setText(`🐰\n${Math.round(lowest)}%\nneeds`);
     } else {
       this.bunnyNameText.setText('No bunny selected');
+      this.compactSummary.setText('🐰\n--');
     }
 
-    // Update room label
     const rooms = ['LivingRoomScene', 'KitchenScene', 'BathroomScene', 'GardenScene', 'BedroomScene', 'VetScene', 'NestScene'];
     const roomNames: Record<string, string> = {
       LivingRoomScene: '🏠 Living Room',
@@ -191,4 +273,4 @@ export class HUDScene extends Phaser.Scene {
   }
 }
 
-export { TOOLBAR_HEIGHT };
+export const TOOLBAR_HEIGHT = 0;


### PR DESCRIPTION
## Summary
- redesigns the stats HUD from a full-width bottom toolbar into a compact right-side rail
- adds collapse/expand behavior with persisted preference in localStorage
- defaults to collapsed on small/mobile viewports while keeping all five core needs visible when expanded
- keeps room navigation, mute, and action buttons available without covering the bunny scene

## Verification
- `cd frontend && ./node_modules/.bin/tsc --noEmit --pretty false`
- `cd frontend && npm run build`

## Notes
Deployment/live verification is intentionally not performed from this PR yet: issue #31 says deploy only with Jonny approval, and the home-lab gateway path is currently unreachable from OpenClaw.

Closes #23
