### PR TITLE
Fix #25: Persistent needs decay loop

### DIFF
--- a/frontend/src/scenes/RoomScene.ts
+++ b/frontend/src/scenes/RoomScene.ts
@@ -4,6 +4,7 @@ import { Bunny } from '../objects/Bunny';
 import { wsClient, type BunnyState } from '../network/WebSocketClient';
 import { getDayNightTint, getSeason } from '../utils/time';
 import { getIdentities, type CharacterIdentity } from '../state/identityRegistry';
+import { applyDecay, catchUpNeeds, legacyStatsFromNeeds, NEEDS_BALANCE, normalizeNeeds, readNeedsState, writeNeedsState, type NeedsState } from '../state/needs';
 import type { LifeStage } from '../config';
 import { isCareAction, type CareAction } from '../game/actions';
 
@@ -13,6 +14,33 @@ const PLAY_AREA_HEIGHT = 480; // Game area above toolbar
 export let gameBunnies: BunnyState[] = [];
 export let selectedBunnyId: string | null = null;
 export let activityLog: string[] = [];
+
+let localNeedsState: NeedsState = catchUpNeeds(readNeedsState());
+writeNeedsState(localNeedsState);
+
+function isServerBackedBunny(bunny: BunnyState): boolean {
+  return bunny.id !== 'father' && bunny.id !== 'mother' && bunny.id !== 'baby';
+}
+
+function syncBabyNeedsToLocalState() {
+  const baby = gameBunnies.find(b => (b.id === 'baby' || b.stage === 'baby') && !isServerBackedBunny(b));
+  if (!baby) return;
+  localNeedsState.needs = normalizeNeeds({
+    hunger: baby.hunger,
+    energy: baby.energy,
+    cleanliness: baby.cleanliness,
+    happiness: baby.happiness,
+    health: baby.health,
+  });
+  localNeedsState.lastTick = Date.now();
+  writeNeedsState(localNeedsState);
+}
+
+function applyLocalNeedsToBaby() {
+  const baby = gameBunnies.find(b => (b.id === 'baby' || b.stage === 'baby') && !isServerBackedBunny(b));
+  if (!baby) return;
+  Object.assign(baby, legacyStatsFromNeeds(localNeedsState.needs));
+}
 
 export function setSelectedBunny(id: string | null) { selectedBunnyId = id; }
 export function addActivity(msg: string) {
@@ -25,15 +53,15 @@ export function ensureDemoBunnies() {
     gameBunnies = [
       { id: 'father', name: 'Mochi', color: 'white', pattern: null, stage: 'adult', hunger: 75, happiness: 80, cleanliness: 60, energy: 70, health: 85, isAlive: true, parentAId: null, parentBId: null },
       { id: 'mother', name: 'Luna', color: 'brown', pattern: null, stage: 'adult', hunger: 82, happiness: 88, cleanliness: 76, energy: 64, health: 90, isAlive: true, parentAId: null, parentBId: null },
-      { id: 'baby', name: 'Boba', color: 'pink', pattern: null, stage: 'baby', hunger: 90, happiness: 95, cleanliness: 80, energy: 50, health: 90, isAlive: true, parentAId: 'father', parentBId: 'mother' },
+      { id: 'baby', name: 'Boba', color: 'pink', pattern: null, stage: 'baby', ...legacyStatsFromNeeds(localNeedsState.needs), isAlive: true, parentAId: 'father', parentBId: 'mother' },
     ];
   }
 }
 
-wsClient.onState((state) => { gameBunnies = state.bunnies; });
+wsClient.onState((state) => { gameBunnies = state.bunnies; syncBabyNeedsToLocalState(); });
 wsClient.onEvent((event) => {
   if (event.message) addActivity(event.message);
-  if (event.type === 'state' && event.bunnies) gameBunnies = event.bunnies;
+  if (event.type === 'state' && event.bunnies) { gameBunnies = event.bunnies; syncBabyNeedsToLocalState(); }
 });
 
 export abstract class RoomScene extends Phaser.Scene {
@@ -59,7 +87,21 @@ export abstract class RoomScene extends Phaser.Scene {
       fontSize: '20px',
     }).setDepth(6);
 
+    applyLocalNeedsToBaby();
     this.spawnBunnies();
+
+    this.time.addEvent({
+      delay: NEEDS_BALANCE.tickMs,
+      loop: true,
+      callback: () => {
+        localNeedsState = {
+          needs: applyDecay(localNeedsState.needs, NEEDS_BALANCE.tickMs),
+          lastTick: Date.now(),
+        };
+        writeNeedsState(localNeedsState);
+        applyLocalNeedsToBaby();
+      },
+    });
 
     this.time.addEvent({
       delay: 60000,
@@ -107,7 +149,7 @@ export abstract class RoomScene extends Phaser.Scene {
     if (!b) return;
 
     const playerName = this.registry.get('playerName') || 'Someone';
-    const emojis: Record<string, string> = { feed: '🍳', clean: '🛁', play: '🎾', sleep: '💤', medicine: '💊', breed: '💕' };
+    const emojis: Record<CareAction, string> = { feed: '🍳', clean: '🛁', play: '🎾', sleep: '💤', medicine: '💊', breed: '💕' };
 
     switch (action) {
       case 'feed': b.hunger = Math.min(100, b.hunger + 25); break;
@@ -115,6 +157,18 @@ export abstract class RoomScene extends Phaser.Scene {
       case 'play': b.happiness = Math.min(100, b.happiness + 20); break;
       case 'sleep': b.energy = Math.min(100, b.energy + 30); break;
       case 'medicine': b.health = Math.min(100, b.health + 20); break;
+    }
+
+    if ((b.id === 'baby' || b.stage === 'baby') && !isServerBackedBunny(b)) {
+      localNeedsState.needs = normalizeNeeds({
+        hunger: b.hunger,
+        energy: b.energy,
+        cleanliness: b.cleanliness,
+        happiness: b.happiness,
+        health: b.health,
+      });
+      localNeedsState.lastTick = Date.now();
+      writeNeedsState(localNeedsState);
     }
 
     const verbs: Record<CareAction, string> = {

--- a/frontend/src/state/needs.ts
+++ b/frontend/src/state/needs.ts
@@ -1,0 +1,153 @@
+export type NeedKey = 'hunger' | 'energy' | 'hygiene' | 'affection' | 'health';
+
+export type Needs = Record<NeedKey, number>;
+
+export type LegacyNeedKey = 'cleanliness' | 'happiness';
+
+export interface NeedsState {
+  needs: Needs;
+  lastTick: number;
+}
+
+export type DecayRates = Partial<Record<NeedKey, number>>;
+
+export interface NeedsBalanceConfig {
+  /** Need decay per hour. */
+  decayPerHour: DecayRates;
+  /** Maximum offline/resume catch-up to apply in one pass. */
+  maxCatchUpMs: number;
+  /** How often active tabs should persist/apply decay. */
+  tickMs: number;
+  /** Health starts drifting down when any core need is below this value. */
+  healthStressThreshold: number;
+  /** Health recovers slowly when all core needs are above this value. */
+  healthRecoveryThreshold: number;
+  /** Health loss per hour while stressed. */
+  healthStressDecayPerHour: number;
+  /** Health recovery per hour while stable. */
+  healthRecoveryPerHour: number;
+}
+
+export const NEED_KEYS: NeedKey[] = ['hunger', 'energy', 'hygiene', 'affection', 'health'];
+
+export const DEFAULT_NEEDS: Needs = {
+  hunger: 90,
+  energy: 70,
+  hygiene: 80,
+  affection: 90,
+  health: 90,
+};
+
+export const NEEDS_BALANCE: NeedsBalanceConfig = {
+  decayPerHour: {
+    hunger: 8,
+    energy: 6,
+    hygiene: 4,
+    affection: 5,
+  },
+  maxCatchUpMs: 6 * 60 * 60 * 1000,
+  tickMs: 30_000,
+  healthStressThreshold: 25,
+  healthRecoveryThreshold: 65,
+  healthStressDecayPerHour: 10,
+  healthRecoveryPerHour: 3,
+};
+
+const STORAGE_KEY = 'bunny-family-needs-v1';
+
+function clampNeed(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(100, Math.round(value * 10) / 10));
+}
+
+export function normalizeNeeds(value: Partial<Needs> & Partial<Record<LegacyNeedKey, number>> = {}): Needs {
+  return {
+    hunger: clampNeed(value.hunger ?? DEFAULT_NEEDS.hunger),
+    energy: clampNeed(value.energy ?? DEFAULT_NEEDS.energy),
+    hygiene: clampNeed(value.hygiene ?? value.cleanliness ?? DEFAULT_NEEDS.hygiene),
+    affection: clampNeed(value.affection ?? value.happiness ?? DEFAULT_NEEDS.affection),
+    health: clampNeed(value.health ?? DEFAULT_NEEDS.health),
+  };
+}
+
+export function applyDecay(
+  needs: Needs,
+  elapsedMs: number,
+  config: NeedsBalanceConfig = NEEDS_BALANCE,
+): Needs {
+  if (!Number.isFinite(elapsedMs) || elapsedMs <= 0) return normalizeNeeds(needs);
+
+  const cappedElapsed = Math.min(elapsedMs, config.maxCatchUpMs);
+  const elapsedHours = cappedElapsed / 3_600_000;
+  const next = normalizeNeeds(needs);
+
+  for (const key of NEED_KEYS) {
+    if (key === 'health') continue;
+    const rate = config.decayPerHour[key] ?? 0;
+    next[key] = clampNeed(next[key] - rate * elapsedHours);
+  }
+
+  const coreNeeds: NeedKey[] = ['hunger', 'energy', 'hygiene', 'affection'];
+  const lowestCoreNeed = Math.min(...coreNeeds.map((key) => next[key]));
+  if (lowestCoreNeed < config.healthStressThreshold) {
+    const stressMultiplier = Math.max(1, (config.healthStressThreshold - lowestCoreNeed) / config.healthStressThreshold);
+    next.health = clampNeed(next.health - config.healthStressDecayPerHour * stressMultiplier * elapsedHours);
+  } else if (lowestCoreNeed >= config.healthRecoveryThreshold) {
+    next.health = clampNeed(next.health + config.healthRecoveryPerHour * elapsedHours);
+  }
+
+  return next;
+}
+
+function sanitizeState(raw: unknown): NeedsState | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const candidate = raw as Partial<NeedsState>;
+  const lastTick = typeof candidate.lastTick === 'number' && Number.isFinite(candidate.lastTick)
+    ? candidate.lastTick
+    : Date.now();
+  return {
+    needs: normalizeNeeds(candidate.needs ?? {}),
+    lastTick,
+  };
+}
+
+export function readNeedsState(now = Date.now()): NeedsState {
+  if (typeof localStorage === 'undefined') return { needs: { ...DEFAULT_NEEDS }, lastTick: now };
+  try {
+    const parsed = JSON.parse(localStorage.getItem(STORAGE_KEY) || 'null');
+    return sanitizeState(parsed) ?? { needs: { ...DEFAULT_NEEDS }, lastTick: now };
+  } catch {
+    return { needs: { ...DEFAULT_NEEDS }, lastTick: now };
+  }
+}
+
+export function writeNeedsState(state: NeedsState) {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      needs: normalizeNeeds(state.needs),
+      lastTick: state.lastTick,
+    }));
+  } catch {
+    // Storage may be unavailable in private/quota-limited sessions. The active
+    // runtime still keeps the current state in memory.
+  }
+}
+
+export function catchUpNeeds(state: NeedsState, now = Date.now(), config: NeedsBalanceConfig = NEEDS_BALANCE): NeedsState {
+  return {
+    needs: applyDecay(state.needs, now - state.lastTick, config),
+    lastTick: now,
+  };
+}
+
+export function legacyStatsFromNeeds(needs: Needs) {
+  const normalized = normalizeNeeds(needs);
+  return {
+    hunger: normalized.hunger,
+    energy: normalized.energy,
+    cleanliness: normalized.hygiene,
+    happiness: normalized.affection,
+    health: normalized.health,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a frontend needs model for hunger, energy, hygiene, affection, and health.
- Adds a pure `applyDecay(needs, elapsedMs, config)` function with tunable balance config and capped catch-up.
- Persists needs + lastTick in localStorage for demo/offline mode and applies active-tab ticks without runaway loops.
- Bridges hygiene/affection to the current HUD fields (`cleanliness`/`happiness`) so existing UI and action buttons keep working.

## Verification
- `cd frontend && npm run build` ✅

## Notes
- This intentionally avoids overriding server-backed bunnies once live persistence is active; local decay only drives the demo/local baby state.

Fixes #25
