### PR TITLE
Fix #27: Server-authoritative save/load

### DIFF
--- a/backend/src/db/migrations/001_init.sql
+++ b/backend/src/db/migrations/001_init.sql
@@ -1,19 +1,19 @@
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
-CREATE TABLE families (
+CREATE TABLE IF NOT EXISTS families (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   name VARCHAR(100) NOT NULL,
   created_at TIMESTAMPTZ DEFAULT NOW()
 );
 
-CREATE TABLE players (
+CREATE TABLE IF NOT EXISTS players (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   family_id UUID REFERENCES families(id) ON DELETE CASCADE,
   name VARCHAR(50) NOT NULL UNIQUE,
   created_at TIMESTAMPTZ DEFAULT NOW()
 );
 
-CREATE TABLE bunnies (
+CREATE TABLE IF NOT EXISTS bunnies (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   family_id UUID REFERENCES families(id) ON DELETE CASCADE,
   name VARCHAR(50) NOT NULL,
@@ -37,7 +37,7 @@ CREATE TABLE bunnies (
   created_at TIMESTAMPTZ DEFAULT NOW()
 );
 
-CREATE TABLE activity_log (
+CREATE TABLE IF NOT EXISTS activity_log (
   id BIGSERIAL PRIMARY KEY,
   family_id UUID REFERENCES families(id) ON DELETE CASCADE,
   player_id UUID REFERENCES players(id) ON DELETE SET NULL,
@@ -47,6 +47,25 @@ CREATE TABLE activity_log (
   created_at TIMESTAMPTZ DEFAULT NOW()
 );
 
-CREATE INDEX idx_bunnies_family_alive ON bunnies(family_id) WHERE is_alive = TRUE;
-CREATE INDEX idx_activity_family_time ON activity_log(family_id, created_at DESC);
-CREATE INDEX idx_players_family ON players(family_id);
+CREATE INDEX IF NOT EXISTS idx_bunnies_family_alive ON bunnies(family_id) WHERE is_alive = TRUE;
+CREATE INDEX IF NOT EXISTS idx_activity_family_time ON activity_log(family_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_players_family ON players(family_id);
+
+CREATE TABLE IF NOT EXISTS player_saves (
+  player_id UUID PRIMARY KEY REFERENCES players(id) ON DELETE CASCADE,
+  father_identity SMALLINT CHECK (father_identity BETWEEN 1 AND 100),
+  mother_identity SMALLINT CHECK (mother_identity BETWEEN 1 AND 100),
+  baby_identity SMALLINT CHECK (baby_identity BETWEEN 1 AND 100),
+  egg_taps SMALLINT NOT NULL DEFAULT 0 CHECK (egg_taps BETWEEN 0 AND 8),
+  egg_hatched BOOLEAN NOT NULL DEFAULT FALSE,
+  egg_seed BIGINT NOT NULL DEFAULT 0,
+  hunger NUMERIC(5,2) NOT NULL DEFAULT 90 CHECK (hunger BETWEEN 0 AND 100),
+  energy NUMERIC(5,2) NOT NULL DEFAULT 70 CHECK (energy BETWEEN 0 AND 100),
+  hygiene NUMERIC(5,2) NOT NULL DEFAULT 80 CHECK (hygiene BETWEEN 0 AND 100),
+  affection NUMERIC(5,2) NOT NULL DEFAULT 90 CHECK (affection BETWEEN 0 AND 100),
+  health NUMERIC(5,2) NOT NULL DEFAULT 90 CHECK (health BETWEEN 0 AND 100),
+  last_tick TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_player_saves_updated ON player_saves(updated_at DESC);

--- a/backend/src/db/queries.ts
+++ b/backend/src/db/queries.ts
@@ -1,5 +1,7 @@
 import { pool } from './pool';
 import type { Bunny, Player, Family, ActivityLogEntry } from '../shared/types';
+import type { PlayerSave, SaveIdentity, SaveNeeds } from '../shared/saveTypes';
+import { defaultSave, normalizeNeeds } from '../game/save';
 
 // Row mappers
 function mapBunny(row: any): Bunny {
@@ -150,4 +152,91 @@ export async function getRecentActivity(familyId: string, limit = 50): Promise<A
     id: r.id, familyId: r.family_id, playerId: r.player_id, bunnyId: r.bunny_id,
     action: r.action, message: r.message, createdAt: r.created_at?.toISOString(),
   }));
+}
+
+
+function identity(role: 'father' | 'mother' | 'baby', index: unknown): SaveIdentity | null {
+  const n = Number(index);
+  return Number.isInteger(n) && n >= 1 && n <= 100 ? { role, identityIndex: n } : null;
+}
+
+function mapPlayerSave(row: any, playerId: string): PlayerSave {
+  if (!row) return defaultSave(playerId);
+  return {
+    version: 1,
+    userId: playerId,
+    father: identity('father', row.father_identity),
+    mother: identity('mother', row.mother_identity),
+    baby: identity('baby', row.baby_identity),
+    egg: {
+      taps: Number(row.egg_taps ?? 0),
+      hatched: row.egg_hatched === true,
+      seed: Number(row.egg_seed ?? 0),
+    },
+    needs: normalizeNeeds({
+      hunger: Number(row.hunger),
+      energy: Number(row.energy),
+      hygiene: Number(row.hygiene),
+      affection: Number(row.affection),
+      health: Number(row.health),
+    }),
+    lastTick: row.last_tick?.toISOString?.() ?? new Date().toISOString(),
+    updatedAt: row.updated_at?.toISOString?.() ?? new Date().toISOString(),
+  };
+}
+
+export async function getOrCreatePlayerSave(playerId: string): Promise<PlayerSave> {
+  await pool.query(
+    `INSERT INTO player_saves (player_id)
+     VALUES ($1)
+     ON CONFLICT (player_id) DO NOTHING`,
+    [playerId],
+  );
+  const res = await pool.query('SELECT * FROM player_saves WHERE player_id = $1', [playerId]);
+  return mapPlayerSave(res.rows[0], playerId);
+}
+
+export async function updatePlayerSave(playerId: string, patch: {
+  father?: SaveIdentity | null;
+  mother?: SaveIdentity | null;
+  baby?: SaveIdentity | null;
+  egg?: { taps: number; hatched: boolean; seed: number };
+  needs?: SaveNeeds;
+  lastTick?: Date;
+}): Promise<PlayerSave> {
+  await getOrCreatePlayerSave(playerId);
+  const res = await pool.query(
+    `UPDATE player_saves SET
+      father_identity = COALESCE($2, father_identity),
+      mother_identity = COALESCE($3, mother_identity),
+      baby_identity = COALESCE($4, baby_identity),
+      egg_taps = COALESCE($5, egg_taps),
+      egg_hatched = COALESCE($6, egg_hatched),
+      egg_seed = COALESCE($7, egg_seed),
+      hunger = COALESCE($8, hunger),
+      energy = COALESCE($9, energy),
+      hygiene = COALESCE($10, hygiene),
+      affection = COALESCE($11, affection),
+      health = COALESCE($12, health),
+      last_tick = COALESCE($13, last_tick),
+      updated_at = NOW()
+     WHERE player_id = $1
+     RETURNING *`,
+    [
+      playerId,
+      patch.father?.identityIndex ?? null,
+      patch.mother?.identityIndex ?? null,
+      patch.baby?.identityIndex ?? null,
+      patch.egg?.taps ?? null,
+      patch.egg?.hatched ?? null,
+      patch.egg?.seed ?? null,
+      patch.needs?.hunger ?? null,
+      patch.needs?.energy ?? null,
+      patch.needs?.hygiene ?? null,
+      patch.needs?.affection ?? null,
+      patch.needs?.health ?? null,
+      patch.lastTick ?? null,
+    ],
+  );
+  return mapPlayerSave(res.rows[0], playerId);
 }

--- a/backend/src/game/save.ts
+++ b/backend/src/game/save.ts
@@ -1,0 +1,127 @@
+import type { CareAction, PlayerSave, SaveEgg, SaveIdentity, SaveNeeds, SaveRole } from '../shared/saveTypes';
+
+export const IDENTITY_COUNT = 100;
+export const HATCH_TAPS = 8;
+
+export const DEFAULT_NEEDS: SaveNeeds = {
+  hunger: 90,
+  energy: 70,
+  hygiene: 80,
+  affection: 90,
+  health: 90,
+};
+
+export const NEEDS_BALANCE = {
+  decayPerHour: {
+    hunger: 8,
+    energy: 6,
+    hygiene: 4,
+    affection: 5,
+  },
+  maxCatchUpMs: 6 * 60 * 60 * 1000,
+  healthStressThreshold: 25,
+  healthRecoveryThreshold: 65,
+  healthStressDecayPerHour: 10,
+  healthRecoveryPerHour: 3,
+};
+
+const ACTION_DELTAS: Record<CareAction, Partial<SaveNeeds>> = {
+  feed: { hunger: 25 },
+  sleep: { energy: 30 },
+  bathe: { hygiene: 30 },
+  play: { affection: 20, energy: -8 },
+  vet: { health: 20 },
+};
+
+function clampNeed(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(100, Math.round(value * 10) / 10));
+}
+
+export function normalizeNeeds(value: Partial<SaveNeeds> = {}): SaveNeeds {
+  return {
+    hunger: clampNeed(value.hunger ?? DEFAULT_NEEDS.hunger),
+    energy: clampNeed(value.energy ?? DEFAULT_NEEDS.energy),
+    hygiene: clampNeed(value.hygiene ?? DEFAULT_NEEDS.hygiene),
+    affection: clampNeed(value.affection ?? DEFAULT_NEEDS.affection),
+    health: clampNeed(value.health ?? DEFAULT_NEEDS.health),
+  };
+}
+
+export function applyDecay(needs: SaveNeeds, elapsedMs: number): SaveNeeds {
+  if (!Number.isFinite(elapsedMs) || elapsedMs <= 0) return normalizeNeeds(needs);
+  const elapsedHours = Math.min(elapsedMs, NEEDS_BALANCE.maxCatchUpMs) / 3_600_000;
+  const next = normalizeNeeds(needs);
+
+  next.hunger = clampNeed(next.hunger - NEEDS_BALANCE.decayPerHour.hunger * elapsedHours);
+  next.energy = clampNeed(next.energy - NEEDS_BALANCE.decayPerHour.energy * elapsedHours);
+  next.hygiene = clampNeed(next.hygiene - NEEDS_BALANCE.decayPerHour.hygiene * elapsedHours);
+  next.affection = clampNeed(next.affection - NEEDS_BALANCE.decayPerHour.affection * elapsedHours);
+
+  const lowest = Math.min(next.hunger, next.energy, next.hygiene, next.affection);
+  if (lowest < NEEDS_BALANCE.healthStressThreshold) {
+    const stressMultiplier = Math.max(1, (NEEDS_BALANCE.healthStressThreshold - lowest) / NEEDS_BALANCE.healthStressThreshold);
+    next.health = clampNeed(next.health - NEEDS_BALANCE.healthStressDecayPerHour * stressMultiplier * elapsedHours);
+  } else if (lowest >= NEEDS_BALANCE.healthRecoveryThreshold) {
+    next.health = clampNeed(next.health + NEEDS_BALANCE.healthRecoveryPerHour * elapsedHours);
+  }
+  return next;
+}
+
+export function applyAction(needs: SaveNeeds, action: CareAction): SaveNeeds {
+  const next = normalizeNeeds(needs);
+  const delta = ACTION_DELTAS[action];
+  for (const [key, amount] of Object.entries(delta) as [keyof SaveNeeds, number][]) {
+    next[key] = clampNeed(next[key] + amount);
+  }
+  return next;
+}
+
+function clampIdentityIndex(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isInteger(value)) return null;
+  return value >= 1 && value <= IDENTITY_COUNT ? value : null;
+}
+
+export function sanitizeIdentity(value: unknown, role: SaveRole): SaveIdentity | null {
+  if (!value || typeof value !== 'object') return null;
+  const candidate = value as Partial<SaveIdentity>;
+  const identityIndex = clampIdentityIndex(candidate.identityIndex);
+  if (candidate.role !== role || identityIndex == null) return null;
+  return { role, identityIndex };
+}
+
+export function sanitizeEgg(value: unknown): SaveEgg {
+  if (!value || typeof value !== 'object') return { taps: 0, hatched: false, seed: 0 };
+  const candidate = value as Partial<SaveEgg>;
+  return {
+    taps: typeof candidate.taps === 'number' ? Math.max(0, Math.min(HATCH_TAPS, Math.trunc(candidate.taps))) : 0,
+    hatched: candidate.hatched === true,
+    seed: typeof candidate.seed === 'number' && Number.isFinite(candidate.seed) ? candidate.seed >>> 0 : 0,
+  };
+}
+
+function pickIdentityIndex(seed: number): number {
+  const v = (seed * 2654435761) >>> 0;
+  return (v % IDENTITY_COUNT) + 1;
+}
+
+export function deriveBabyIdentity(father: SaveIdentity | null, mother: SaveIdentity | null, seed: number): SaveIdentity {
+  const derivedSeed = seed
+    ^ (father?.identityIndex ?? 0) * 0x9e3779b1
+    ^ (mother?.identityIndex ?? 0) * 0x85ebca6b;
+  return { role: 'baby', identityIndex: pickIdentityIndex(derivedSeed >>> 0) };
+}
+
+export function defaultSave(userId: string, now = new Date()): PlayerSave {
+  return {
+    version: 1,
+    userId,
+    father: null,
+    mother: null,
+    baby: null,
+    egg: { taps: 0, hatched: false, seed: 0 },
+    needs: { ...DEFAULT_NEEDS },
+    lastTick: now.toISOString(),
+    updatedAt: now.toISOString(),
+  };
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -13,6 +13,8 @@ import { stopAllTicks } from './game/tick';
 import { generateBunnyName } from './game/names';
 import { catchUpFamily } from './game/tick';
 import { broadcastToFamily } from './ws/rooms';
+import { applyAction as applySaveAction, applyDecay as applySaveDecay, deriveBabyIdentity, sanitizeEgg, sanitizeIdentity } from './game/save';
+import type { CareAction } from './shared/saveTypes';
 
 const app = express();
 app.use(cors());
@@ -62,6 +64,93 @@ app.post('/login', async (req, res) => {
     res.json({ player, family });
   } catch (err: any) {
     console.error('Login error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+
+async function requirePlayer(req: express.Request, res: express.Response) {
+  const userId = req.header('x-player-id') || req.query.userId;
+  if (!userId || typeof userId !== 'string') {
+    res.status(401).json({ error: 'x-player-id header is required' });
+    return null;
+  }
+  const player = await db.getPlayerById(userId);
+  if (!player) {
+    res.status(404).json({ error: 'Player not found' });
+    return null;
+  }
+  return player;
+}
+
+async function getCaughtUpSave(playerId: string) {
+  const save = await db.getOrCreatePlayerSave(playerId);
+  const now = new Date();
+  const lastTick = new Date(save.lastTick).getTime();
+  const needs = applySaveDecay(save.needs, now.getTime() - lastTick);
+  return db.updatePlayerSave(playerId, { needs, lastTick: now });
+}
+
+app.get('/api/save', async (req, res) => {
+  try {
+    const player = await requirePlayer(req, res);
+    if (!player) return;
+    res.json(await getCaughtUpSave(player.id));
+  } catch (err: any) {
+    console.error('Save fetch error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+app.post('/api/save/needs', async (req, res) => {
+  try {
+    const player = await requirePlayer(req, res);
+    if (!player) return;
+    const action = req.body?.action as CareAction | undefined;
+    if (action && !['feed', 'sleep', 'bathe', 'play', 'vet'].includes(action)) {
+      return res.status(400).json({ error: 'Unsupported action' });
+    }
+    const caughtUp = await getCaughtUpSave(player.id);
+    const now = new Date();
+    const needs = action ? applySaveAction(caughtUp.needs, action) : caughtUp.needs;
+    const save = await db.updatePlayerSave(player.id, { needs, lastTick: now });
+    res.json(save);
+  } catch (err: any) {
+    console.error('Save needs error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+app.post('/api/save/hatch', async (req, res) => {
+  try {
+    const player = await requirePlayer(req, res);
+    if (!player) return;
+    const save = await getCaughtUpSave(player.id);
+    if (save.egg.hatched || save.baby) {
+      return res.status(409).json({ error: 'Egg already hatched', save });
+    }
+
+    const father = sanitizeIdentity(req.body?.father, 'father') ?? save.father;
+    const mother = sanitizeIdentity(req.body?.mother, 'mother') ?? save.mother;
+    const requestedEgg = sanitizeEgg(req.body?.egg ?? save.egg);
+    const egg = {
+      ...requestedEgg,
+      taps: Math.max(save.egg.taps, requestedEgg.taps),
+      seed: requestedEgg.seed || save.egg.seed,
+      hatched: false,
+    };
+
+    if (!father || !mother || egg.taps < 8) {
+      return res.status(400).json({ error: 'Father, mother, and 8 egg taps are required' });
+    }
+
+    egg.hatched = true;
+    egg.taps = 8;
+    const baby = deriveBabyIdentity(father, mother, egg.seed);
+    const updated = await db.updatePlayerSave(player.id, { father, mother, baby, egg, lastTick: new Date() });
+    res.json(updated);
+  } catch (err: any) {
+    console.error('Save hatch error:', err);
     res.status(500).json({ error: 'Internal server error' });
   }
 });

--- a/backend/src/shared/saveTypes.ts
+++ b/backend/src/shared/saveTypes.ts
@@ -1,0 +1,34 @@
+export type SaveRole = 'father' | 'mother' | 'baby';
+
+export interface SaveIdentity {
+  role: SaveRole;
+  identityIndex: number;
+}
+
+export interface SaveEgg {
+  taps: number;
+  hatched: boolean;
+  seed: number;
+}
+
+export interface SaveNeeds {
+  hunger: number;
+  energy: number;
+  hygiene: number;
+  affection: number;
+  health: number;
+}
+
+export interface PlayerSave {
+  version: 1;
+  userId: string;
+  father: SaveIdentity | null;
+  mother: SaveIdentity | null;
+  baby: SaveIdentity | null;
+  egg: SaveEgg;
+  needs: SaveNeeds;
+  lastTick: string;
+  updatedAt: string;
+}
+
+export type CareAction = 'feed' | 'sleep' | 'bathe' | 'play' | 'vet';

--- a/frontend/src/network/SaveClient.ts
+++ b/frontend/src/network/SaveClient.ts
@@ -1,0 +1,71 @@
+import type { IdentitySave } from '../state/identityRegistry';
+import type { Needs } from '../state/needs';
+
+export type CareAction = 'feed' | 'sleep' | 'bathe' | 'play' | 'vet';
+
+export interface ServerSave extends IdentitySave {
+  userId: string;
+  needs: Needs;
+  lastTick: string;
+  updatedAt: string;
+}
+
+class SaveClient {
+  private playerId = '';
+  private cache: ServerSave | null = null;
+
+  setPlayerId(playerId: string) {
+    this.playerId = playerId;
+  }
+
+  getPlayerId() { return this.playerId; }
+  getCachedSave() { return this.cache; }
+
+  private headers() {
+    return {
+      'Content-Type': 'application/json',
+      'x-player-id': this.playerId,
+    };
+  }
+
+  private async request(path: string, init: RequestInit = {}): Promise<ServerSave | null> {
+    if (!this.playerId) return null;
+    const baseUrl = `${window.location.protocol}//${window.location.host}`;
+    const res = await fetch(`${baseUrl}${path}`, {
+      ...init,
+      headers: { ...this.headers(), ...(init.headers || {}) },
+    });
+    if (!res.ok) {
+      if (res.status === 409) {
+        const payload = await res.json().catch(() => null);
+        if (payload?.save) {
+          this.cache = payload.save;
+          return this.cache;
+        }
+      }
+      throw new Error(`Save request failed: ${res.status}`);
+    }
+    this.cache = await res.json();
+    return this.cache;
+  }
+
+  async loadSave() {
+    return this.request('/api/save');
+  }
+
+  async applyAction(action: CareAction) {
+    return this.request('/api/save/needs', {
+      method: 'POST',
+      body: JSON.stringify({ action }),
+    });
+  }
+
+  async hatch(save: IdentitySave) {
+    return this.request('/api/save/hatch', {
+      method: 'POST',
+      body: JSON.stringify({ father: save.father, mother: save.mother, egg: save.egg }),
+    });
+  }
+}
+
+export const saveClient = new SaveClient();

--- a/frontend/src/network/WebSocketClient.ts
+++ b/frontend/src/network/WebSocketClient.ts
@@ -1,4 +1,6 @@
 import { WS_URL } from '../config';
+import { saveClient } from './SaveClient';
+import { hydrateIdentities } from '../state/identityRegistry';
 
 export interface BunnyState {
   id: string;
@@ -61,6 +63,9 @@ export class WebSocketClient {
         const data = await res.json();
         this.familyId = data.player?.familyId || data.family?.id || '';
         this.playerId = data.player?.id || '';
+        saveClient.setPlayerId(this.playerId);
+        const save = await saveClient.loadSave().catch((err) => { console.warn('Save load failed, using local fallback', err); return null; });
+        if (save) hydrateIdentities(save);
         console.log('Login success:', { familyId: this.familyId, playerId: this.playerId });
       } else {
         console.warn('Login failed with status:', res.status);

--- a/frontend/src/scenes/LoginScene.ts
+++ b/frontend/src/scenes/LoginScene.ts
@@ -116,11 +116,11 @@ export class LoginScene extends Phaser.Scene {
 
     btn.on('pointerover', () => btn.setScale(1.08));
     btn.on('pointerout', () => btn.setScale(1));
-    btn.on('pointerdown', () => {
+    btn.on('pointerdown', async () => {
       playClick();
       startBGMusic();
       this.registry.set('playerName', name);
-      wsClient.connect(name);
+      await wsClient.connect(name);
       // First-run / mid-hatch users see the onboarding nest. Once the baby
       // has hatched the save persists, so returning users land in the rooms.
       if (isHatched()) {

--- a/frontend/src/scenes/OnboardingNestScene.ts
+++ b/frontend/src/scenes/OnboardingNestScene.ts
@@ -298,11 +298,19 @@ export class OnboardingNestScene extends Phaser.Scene {
     }
   }
 
-  private startHatch() {
+  private async startHatch() {
     this.hatching = true;
     this.tapHint.setText('💖 The egg is hatching! 💖');
     playHatch();
-    const baby = performHatch();
+    let baby: CharacterIdentity;
+    try {
+      const { saveClient } = await import('../network/SaveClient');
+      const serverSave = await saveClient.hatch(getIdentities());
+      baby = performHatch(serverSave?.baby ?? null);
+    } catch (err) {
+      console.warn('Server hatch failed, using local fallback', err);
+      baby = performHatch();
+    }
 
     this.tweens.killTweensOf(this.eggContainer);
     this.tweens.add({

--- a/frontend/src/scenes/RoomScene.ts
+++ b/frontend/src/scenes/RoomScene.ts
@@ -2,6 +2,7 @@ import Phaser from 'phaser';
 import { GAME_WIDTH, GAME_HEIGHT } from '../config';
 import { Bunny } from '../objects/Bunny';
 import { wsClient, type BunnyState } from '../network/WebSocketClient';
+import { saveClient, type CareAction as SaveCareAction } from '../network/SaveClient';
 import { getDayNightTint, getSeason } from '../utils/time';
 import { getIdentities, type CharacterIdentity } from '../state/identityRegistry';
 import { applyDecay, catchUpNeeds, legacyStatsFromNeeds, NEEDS_BALANCE, normalizeNeeds, readNeedsState, writeNeedsState, type NeedsState } from '../state/needs';
@@ -145,7 +146,7 @@ export abstract class RoomScene extends Phaser.Scene {
     });
   }
 
-  protected applyAction(action: CareAction, bunnyId: string) {
+  protected async applyAction(action: CareAction, bunnyId: string) {
     const b = gameBunnies.find(x => x.id === bunnyId);
     if (!b) return;
 
@@ -153,12 +154,34 @@ export abstract class RoomScene extends Phaser.Scene {
     const emojis: Record<CareAction, string> = { feed: '🍳', clean: '🛁', play: '🎾', sleep: '💤', medicine: '💊', breed: '💕' };
 
     switch (action) {
-      case 'feed': b.hunger = Math.min(100, b.hunger + 25); playFeed(); break;
-      case 'clean': b.cleanliness = Math.min(100, b.cleanliness + 30); playClean(); break;
-      case 'play': b.happiness = Math.min(100, b.happiness + 20); playPlay(); break;
-      case 'sleep': b.energy = Math.min(100, b.energy + 30); playSleep(); break;
-      case 'medicine': b.health = Math.min(100, b.health + 20); playMedicine(); break;
+      case 'feed': playFeed(); break;
+      case 'clean': playClean(); break;
+      case 'play': playPlay(); break;
+      case 'sleep': playSleep(); break;
+      case 'medicine': playMedicine(); break;
       case 'breed': playBreed(); break;
+    }
+
+    const serverActionMap: Partial<Record<CareAction, SaveCareAction>> = { feed: 'feed', clean: 'bathe', play: 'play', sleep: 'sleep', medicine: 'vet' };
+    const serverAction = serverActionMap[action];
+    const serverSave = serverAction
+      ? await saveClient.applyAction(serverAction).catch((err: unknown) => { console.warn('Server action failed, using local fallback', err); return null; })
+      : null;
+
+    if (serverSave) {
+      b.hunger = serverSave.needs.hunger;
+      b.cleanliness = serverSave.needs.hygiene;
+      b.happiness = serverSave.needs.affection;
+      b.energy = serverSave.needs.energy;
+      b.health = serverSave.needs.health;
+    } else {
+      switch (action) {
+        case 'feed': b.hunger = Math.min(100, b.hunger + 25); break;
+        case 'clean': b.cleanliness = Math.min(100, b.cleanliness + 30); break;
+        case 'play': b.happiness = Math.min(100, b.happiness + 20); b.energy = Math.max(0, b.energy - 8); break;
+        case 'sleep': b.energy = Math.min(100, b.energy + 30); break;
+        case 'medicine': b.health = Math.min(100, b.health + 20); break;
+      }
     }
 
     if ((b.id === 'baby' || b.stage === 'baby') && !isServerBackedBunny(b)) {

--- a/frontend/src/state/identityRegistry.ts
+++ b/frontend/src/state/identityRegistry.ts
@@ -1,16 +1,9 @@
 // Local identity registry for the Bunny Family onboarding flow.
 //
-// Stable per-character identity is the core user-vision constraint: father stays
-// the same father across rooms/reloads; mother stays the same mother; the baby
-// keeps the identity it gets at hatch. We store the minimum needed to reproduce
-// that selection, plus the egg's tap progress so a partial-hatch survives a
-// reload.
-//
-// The registry currently uses localStorage. When a server-authoritative save
-// arrives this module is the single place to switch to a fetch/save API; the
-// rest of the frontend should keep talking to `getIdentities()` / `saveX()`.
+// The server save is authoritative when available; localStorage remains as an
+// offline/demo fallback so the game still works while the backend is down.
 
-const STORAGE_KEY = 'bunny-family.v1';
+const STORAGE_KEY = '***';
 
 export type CharacterRole = 'father' | 'mother' | 'baby';
 export type CharacterState =
@@ -67,6 +60,16 @@ function cloneDefaultSave(): IdentitySave {
   return {
     ...DEFAULT_SAVE,
     egg: { ...DEFAULT_SAVE.egg },
+  };
+}
+
+function cloneSave(save: IdentitySave): IdentitySave {
+  return {
+    version: 1,
+    father: save.father ? { ...save.father } : null,
+    mother: save.mother ? { ...save.mother } : null,
+    baby: save.baby ? { ...save.baby } : null,
+    egg: { ...save.egg },
   };
 }
 
@@ -129,6 +132,12 @@ function writeStorage(save: IdentitySave) {
 
 let cache: IdentitySave = readStorage();
 
+export function hydrateIdentities(save: IdentitySave | null | undefined) {
+  if (!save) return;
+  cache = cloneSave(save);
+  writeStorage(cache);
+}
+
 export function getIdentities(): IdentitySave {
   return cache;
 }
@@ -142,8 +151,6 @@ export function isOnboardingComplete(): boolean {
 }
 
 function pickIdentityIndex(seed: number): number {
-  // Lightweight deterministic pick — good enough for visual stability.
-  // A future server-side roll can replace this without API changes.
   const v = (seed * 2654435761) >>> 0;
   return (v % IDENTITY_COUNT) + 1;
 }
@@ -181,19 +188,20 @@ export function shouldHatch(): boolean {
   return !cache.egg.hatched && cache.egg.taps >= HATCH_TAPS;
 }
 
-export function performHatch(): CharacterIdentity {
+export function performHatch(serverBaby?: CharacterIdentity | null): CharacterIdentity {
   if (cache.baby) return cache.baby;
   const father = cache.father;
   const mother = cache.mother;
   const seed = cache.egg.seed
     ^ (father?.identityIndex ?? 0) * 0x9e3779b1
     ^ (mother?.identityIndex ?? 0) * 0x85ebca6b;
-  const baby: CharacterIdentity = {
+  const baby: CharacterIdentity = serverBaby ?? {
     role: 'baby',
     identityIndex: pickIdentityIndex(seed >>> 0),
   };
   cache.baby = baby;
   cache.egg.hatched = true;
+  cache.egg.taps = HATCH_TAPS;
   writeStorage(cache);
   return baby;
 }


### PR DESCRIPTION
## Summary
- adds server-authoritative per-player save records for father/mother/baby identities, egg state, needs, and last tick
- exposes `/api/save`, `/api/save/needs`, and `/api/save/hatch` with player ownership via `x-player-id`
- applies capped server-side needs decay and care actions before returning saves
- hydrates frontend identities from the backend after login, persists hatch server-side, and keeps localStorage only as offline/demo fallback

## Verification
- `npm --prefix backend run build` ✅
- `npm --prefix frontend run build` ✅
- `npm --prefix backend run migrate` blocked locally because no local Postgres is running (`ECONNREFUSED 127.0.0.1:5432`), but migration SQL is idempotent (`IF NOT EXISTS`) for live deployment.

## Notes
Deployment/live verification is blocked from this runner by the current home-lab gateway route outage, and issue #31 requires Jonny approval before MVP deployment.

Fixes #27
