### PR TITLE
Fix #28: Security hardening pass

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,34 @@
+name: Security and build checks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Block obvious committed secrets
+        run: |
+          set -euo pipefail
+          if grep -RInE '(github[_]pat_|ghp[_]|AIza[0-9A-Za-z_-]{35}|sk-[A-Za-z0-9]{20,}|BEGIN (RSA|OPENSSH|EC|DSA) PRIVATE KEY|pass[word]\s*[:=]\s*[^[:space:]]+)' \
+            --exclude-dir=.git --exclude-dir=node_modules --exclude='package-lock.json' .; then
+            echo 'Potential secret found in repository content.' >&2
+            exit 1
+          fi
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Backend build
+        working-directory: backend
+        run: npm ci && npm run build
+      - name: Frontend build
+        working-directory: frontend
+        run: npm ci && npm run build

--- a/backend/src/db/queries.ts
+++ b/backend/src/db/queries.ts
@@ -64,6 +64,11 @@ export async function getFamily(familyId: string): Promise<Family | null> {
 }
 
 // Players
+export async function getPlayerById(playerId: string): Promise<Player | null> {
+  const res = await pool.query('SELECT * FROM players WHERE id = $1', [playerId]);
+  return res.rows.length > 0 ? mapPlayer(res.rows[0]) : null;
+}
+
 export async function getOrCreatePlayer(familyId: string, name: string): Promise<Player> {
   const existing = await pool.query('SELECT * FROM players WHERE name = $1', [name]);
   if (existing.rows.length > 0) return mapPlayer(existing.rows[0]);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -134,7 +134,20 @@ wss.on('connection', async (ws: WebSocket, req) => {
       return;
     }
   } else {
-    console.log(`🔌 ${playerName} connected to family ${familyId}`);
+    try {
+      const player = await db.getPlayerById(playerId);
+      if (!player || player.familyId !== familyId) {
+        ws.send(JSON.stringify({ type: 'error', message: 'Player is not allowed to access this save' }));
+        ws.close();
+        return;
+      }
+      console.log(`🔌 ${playerName} connected to family ${familyId}`);
+    } catch (err) {
+      console.error('WS ownership check failed:', err);
+      ws.send(JSON.stringify({ type: 'error', message: 'Failed to validate player' }));
+      ws.close();
+      return;
+    }
   }
 
   handleConnection(ws, familyId, playerId, playerName);

--- a/backend/src/ws/handler.ts
+++ b/backend/src/ws/handler.ts
@@ -1,12 +1,33 @@
 import WebSocket from 'ws';
-import type { ClientMessage } from '../shared/types';
+import type { ActionType, ClientMessage } from '../shared/types';
 import { performAction } from '../game/actions';
 import { catchUpFamily, startFamilyTick, stopFamilyTick } from '../game/tick';
 import { getPlayerFromWs, broadcastToFamily, joinRoom, leaveRoom, getRoomSize } from './rooms';
 import * as db from '../db/queries';
 
+const VALID_ACTIONS = new Set<ActionType>(['feed', 'clean', 'play', 'sleep', 'medicine', 'breed']);
+const ACTION_COOLDOWN_MS: Record<ActionType, number> = {
+  feed: 1_500,
+  clean: 1_500,
+  play: 1_500,
+  sleep: 2_500,
+  medicine: 10_000,
+  breed: 10_000,
+};
+const MAX_ACTIONS_PER_WINDOW = 12;
+const ACTION_WINDOW_MS = 10_000;
+
+interface RateState {
+  lastByKey: Map<string, number>;
+  windowStart: number;
+  count: number;
+}
+
+const rateStates = new WeakMap<WebSocket, RateState>();
+
 export function handleConnection(ws: WebSocket, familyId: string, playerId: string, playerName: string) {
   joinRoom(ws, { ws, playerId, playerName, familyId });
+  rateStates.set(ws, { lastByKey: new Map(), windowStart: Date.now(), count: 0 });
 
   // Catch up decay and send initial state
   catchUpFamily(familyId, broadcastToFamily).then(async () => {
@@ -23,8 +44,12 @@ export function handleConnection(ws: WebSocket, familyId: string, playerId: stri
 
   ws.on('message', async (raw) => {
     try {
-      const msg: ClientMessage = JSON.parse(raw.toString());
-      await handleMessage(ws, msg);
+      const parsed = JSON.parse(raw.toString());
+      if (!isClientMessage(parsed)) {
+        ws.send(JSON.stringify({ type: 'error', message: 'Invalid message' }));
+        return;
+      }
+      await handleMessage(ws, parsed);
     } catch (err: any) {
       console.error('WS message error:', err);
       ws.send(JSON.stringify({ type: 'error', message: err.message || 'Unknown error' }));
@@ -32,11 +57,53 @@ export function handleConnection(ws: WebSocket, familyId: string, playerId: stri
   });
 
   ws.on('close', () => {
+    rateStates.delete(ws);
     leaveRoom(ws, familyId);
     if (getRoomSize(familyId) === 0) {
       stopFamilyTick(familyId);
     }
   });
+}
+
+function isSafeId(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && value.length <= 80 && /^[A-Za-z0-9_-]+$/.test(value);
+}
+
+function isClientMessage(value: unknown): value is ClientMessage {
+  if (!value || typeof value !== 'object') return false;
+  const msg = value as Partial<ClientMessage> & Record<string, unknown>;
+  if (msg.type === 'ping') return true;
+  if (msg.type !== 'action') return false;
+  if (typeof msg.action !== 'string' || !VALID_ACTIONS.has(msg.action as ActionType)) return false;
+  if (!isSafeId(msg.bunnyId)) return false;
+  if (msg.targetBunnyId != null && !isSafeId(msg.targetBunnyId)) return false;
+  return true;
+}
+
+function checkActionRate(ws: WebSocket, action: ActionType, bunnyId: string): { ok: true } | { ok: false; message: string } {
+  const now = Date.now();
+  const state = rateStates.get(ws) ?? { lastByKey: new Map<string, number>(), windowStart: now, count: 0 };
+  rateStates.set(ws, state);
+
+  if (now - state.windowStart > ACTION_WINDOW_MS) {
+    state.windowStart = now;
+    state.count = 0;
+  }
+
+  state.count += 1;
+  if (state.count > MAX_ACTIONS_PER_WINDOW) {
+    return { ok: false, message: 'Slow down — too many actions at once.' };
+  }
+
+  const key = `${action}:${bunnyId}`;
+  const last = state.lastByKey.get(key) ?? 0;
+  const cooldown = ACTION_COOLDOWN_MS[action];
+  if (now - last < cooldown) {
+    return { ok: false, message: 'That action is cooling down.' };
+  }
+
+  state.lastByKey.set(key, now);
+  return { ok: true };
 }
 
 async function handleMessage(ws: WebSocket, msg: ClientMessage) {
@@ -49,6 +116,19 @@ async function handleMessage(ws: WebSocket, msg: ClientMessage) {
     const player = getPlayerFromWs(ws);
     if (!player) return;
 
+    const rate = checkActionRate(ws, msg.action, msg.bunnyId);
+    if (!rate.ok) {
+      ws.send(JSON.stringify({ type: 'error', message: rate.message }));
+      return;
+    }
+
+    const dbPlayer = await db.getPlayerById(player.playerId);
+    if (!dbPlayer || dbPlayer.familyId !== player.familyId) {
+      ws.send(JSON.stringify({ type: 'error', message: 'Player is not allowed to edit this save' }));
+      ws.close();
+      return;
+    }
+
     const bunnies = await db.getAliveBunnies(player.familyId);
     const bunny = bunnies.find(b => b.id === msg.bunnyId);
     if (!bunny) {
@@ -59,6 +139,10 @@ async function handleMessage(ws: WebSocket, msg: ClientMessage) {
     let targetBunny;
     if (msg.action === 'breed' && msg.targetBunnyId) {
       targetBunny = bunnies.find(b => b.id === msg.targetBunnyId);
+      if (!targetBunny) {
+        ws.send(JSON.stringify({ type: 'error', message: 'Target bunny not found' }));
+        return;
+      }
     }
 
     const result = await performAction(msg.action, bunny, player.playerName, player.playerId, targetBunny);

--- a/docs/security-checks-issue-28.md
+++ b/docs/security-checks-issue-28.md
@@ -1,0 +1,20 @@
+# Issue #28 security checks
+
+Implemented hardening:
+
+- WebSocket action messages are schema-validated before handling.
+- The server ignores client-supplied `playerId` in action payloads and uses the authenticated WebSocket session player.
+- A provided `familyId` + `playerId` connection must match an existing player record, preventing cross-save reads/writes.
+- Action events are server-rate-limited by connection/window and by action+bunny cooldown.
+- Bunny and target bunny lookup is constrained to the connected player's family.
+- Asset paths remain constructed only by `assetFor()` / `bunnyAssetRef()` from validated kind/index/state tuples.
+- GitHub Actions adds a build gate plus an obvious-secret scanner.
+
+Penetration-style checklist:
+
+- Replay burst of action WebSocket messages: rejected after the short per-action cooldown/window limit.
+- Cross-user save attempt using another `familyId` with mismatched `playerId`: WebSocket sends an error and closes.
+- Action against a bunny id outside the connected family: rejected as `Bunny not found`.
+- Target-bunny tampering for breeding outside the connected family: rejected as `Target bunny not found`.
+- Asset traversal such as `../../secret`: no raw path input is accepted by the frontend asset resolver.
+- Local hatch override: currently remains local-only onboarding state; server action/save mutation is authoritative for backend bunny state, and server-side hatch persistence should be wired when the #27 server-save PR lands.


### PR DESCRIPTION
Fixes #28.

## What changed
- Validates WebSocket client messages before handling actions.
- Enforces server-side action rate limits / cooldowns for tap/action spam protection.
- Verifies `familyId` + `playerId` ownership on WebSocket connect and before mutations.
- Keeps bunny and breeding target lookups scoped to the connected player's family.
- Adds CI build checks plus an obvious-secret scanner.
- Documents penetration-style checks in `docs/security-checks-issue-28.md`.

## Verification
- `npm --prefix backend run build`
- `npm --prefix frontend run build`
- local secret scan over backend/frontend/k8s/.github/docs
