### PR TITLE
Fix #26: Action cooldown UI

### DIFF
--- a/frontend/src/game/actions.ts
+++ b/frontend/src/game/actions.ts
@@ -1,0 +1,32 @@
+export type CareAction = 'feed' | 'clean' | 'play' | 'sleep' | 'medicine' | 'breed';
+
+export interface CareActionConfig {
+  label: string;
+  shortLabel: string;
+  action: CareAction;
+  cooldownMs: number;
+  mood: 'eating' | 'sleeping' | 'playing' | 'happy';
+}
+
+export const CARE_ACTIONS: CareActionConfig[] = [
+  { label: '🍳 Feed', shortLabel: 'Feed', action: 'feed', cooldownMs: 1_500, mood: 'eating' },
+  { label: '🛁 Bathe', shortLabel: 'Bathe', action: 'clean', cooldownMs: 1_500, mood: 'happy' },
+  { label: '🎾 Play', shortLabel: 'Play', action: 'play', cooldownMs: 1_500, mood: 'playing' },
+  { label: '💤 Sleep', shortLabel: 'Sleep', action: 'sleep', cooldownMs: 2_500, mood: 'sleeping' },
+  { label: '💊 Vet', shortLabel: 'Vet', action: 'medicine', cooldownMs: 10_000, mood: 'happy' },
+  { label: '💕 Breed', shortLabel: 'Breed', action: 'breed', cooldownMs: 10_000, mood: 'happy' },
+];
+
+export const ACTION_COOLDOWNS = CARE_ACTIONS.reduce((acc, item) => {
+  acc[item.action] = item.cooldownMs;
+  return acc;
+}, {} as Record<CareAction, number>);
+
+export const ACTION_LABELS = CARE_ACTIONS.reduce((acc, item) => {
+  acc[item.action] = item.shortLabel;
+  return acc;
+}, {} as Record<CareAction, string>);
+
+export function isCareAction(action: string): action is CareAction {
+  return CARE_ACTIONS.some(item => item.action === action);
+}

--- a/frontend/src/objects/ActionButton.ts
+++ b/frontend/src/objects/ActionButton.ts
@@ -4,10 +4,14 @@ import { playClick } from '../utils/sound';
 export class ActionButton extends Phaser.GameObjects.Container {
   private bg: Phaser.GameObjects.Rectangle;
   private label: Phaser.GameObjects.Text;
+  private cooldownText: Phaser.GameObjects.Text;
+  private disabled = false;
+  private baseColor: number;
 
   constructor(scene: Phaser.Scene, x: number, y: number, text: string, color: number, onClick: () => void, width = 100, height = 44) {
     super(scene, x, y);
 
+    this.baseColor = color;
     this.bg = scene.add.rectangle(0, 0, width, height, color, 0.92)
       .setStrokeStyle(2, 0xffffff, 0.25)
       .setInteractive({ useHandCursor: true });
@@ -23,23 +27,55 @@ export class ActionButton extends Phaser.GameObjects.Container {
     }).setOrigin(0.5);
     this.add(this.label);
 
+    this.cooldownText = scene.add.text(0, height / 2 - 10, '', {
+      fontFamily: 'Arial, sans-serif',
+      fontSize: '10px',
+      color: '#ffffff',
+      stroke: '#00000088',
+      strokeThickness: 2,
+      fontStyle: 'bold',
+    }).setOrigin(0.5).setVisible(false);
+    this.add(this.cooldownText);
+
     this.bg.on('pointerover', () => {
-      this.bg.setFillStyle(color, 1);
+      if (this.disabled) return;
+      this.bg.setFillStyle(this.baseColor, 1);
       this.setScale(1.08);
     });
     this.bg.on('pointerout', () => {
-      this.bg.setFillStyle(color, 0.92);
+      if (this.disabled) return;
+      this.bg.setFillStyle(this.baseColor, 0.92);
       this.setScale(1);
     });
     this.bg.on('pointerdown', () => {
+      if (this.disabled) return;
       playClick();
       this.setScale(0.94);
       onClick();
     });
     this.bg.on('pointerup', () => {
-      this.setScale(1.08);
+      if (!this.disabled) this.setScale(1.08);
     });
 
     scene.add.existing(this);
+  }
+
+  setCooldown(remainingMs: number) {
+    if (remainingMs > 0) {
+      this.disabled = true;
+      this.bg.disableInteractive();
+      this.bg.setFillStyle(0x555566, 0.72);
+      this.setScale(1);
+      this.setAlpha(0.72);
+      this.cooldownText.setText(`${Math.ceil(remainingMs / 1000)}s`);
+      this.cooldownText.setVisible(true);
+      return;
+    }
+
+    this.disabled = false;
+    this.bg.setInteractive({ useHandCursor: true });
+    this.bg.setFillStyle(this.baseColor, 0.92);
+    this.setAlpha(1);
+    this.cooldownText.setVisible(false);
   }
 }

--- a/frontend/src/scenes/HUDScene.ts
+++ b/frontend/src/scenes/HUDScene.ts
@@ -5,6 +5,7 @@ import { ActionButton } from '../objects/ActionButton';
 import { gameBunnies, selectedBunnyId, activityLog, setSelectedBunny } from './RoomScene';
 import { wsClient, type BunnyState } from '../network/WebSocketClient';
 import { toggleMute, isMuted } from '../utils/sound';
+import { ACTION_COOLDOWNS, CARE_ACTIONS, type CareAction } from '../game/actions';
 
 const TOOLBAR_HEIGHT = 120;
 const PANEL_Y = GAME_HEIGHT - TOOLBAR_HEIGHT;
@@ -14,6 +15,8 @@ export class HUDScene extends Phaser.Scene {
   private bunnyNameText!: Phaser.GameObjects.Text;
   private muteBtn!: Phaser.GameObjects.Text;
   private roomLabel!: Phaser.GameObjects.Text;
+  private actionButtons = new Map<CareAction, ActionButton>();
+  private cooldownUntil = new Map<CareAction, number>();
 
   constructor() { super({ key: 'HUDScene' }); }
 
@@ -43,22 +46,22 @@ export class HUDScene extends Phaser.Scene {
       health: new StatBar(this, barX + 310, barY, '❤️ HP', COLORS.health, 90),
     };
 
-    // Action buttons row
-    const actions = [
-      { text: '🍳 Feed', color: COLORS.btnFeed, action: 'feed' },
-      { text: '🛁 Clean', color: COLORS.btnClean, action: 'clean' },
-      { text: '🎾 Play', color: COLORS.btnPlay, action: 'play' },
-      { text: '💤 Sleep', color: COLORS.btnSleep, action: 'sleep' },
-      { text: '💊 Heal', color: COLORS.btnMedicine, action: 'medicine' },
-      { text: '💕 Breed', color: COLORS.btnBreed, action: 'breed' },
-    ];
-
+    // Action buttons row with visible client-side cooldowns.
+    const actionColors: Record<CareAction, number> = {
+      feed: COLORS.btnFeed,
+      clean: COLORS.btnClean,
+      play: COLORS.btnPlay,
+      sleep: COLORS.btnSleep,
+      medicine: COLORS.btnMedicine,
+      breed: COLORS.btnBreed,
+    };
     const btnY = PANEL_Y + 88;
-    const btnSpacing = GAME_WIDTH / (actions.length + 1);
-    actions.forEach((a, i) => {
-      new ActionButton(this, btnSpacing * (i + 1), btnY, a.text, a.color, () => {
+    const btnSpacing = GAME_WIDTH / (CARE_ACTIONS.length + 1);
+    CARE_ACTIONS.forEach((a, i) => {
+      const btn = new ActionButton(this, btnSpacing * (i + 1), btnY, a.label, actionColors[a.action], () => {
         this.doRoomAction(a.action);
       }, 110, 36);
+      this.actionButtons.set(a.action, btn);
     });
 
     // Navigation arrows (above toolbar, on left/right edges)
@@ -103,7 +106,10 @@ export class HUDScene extends Phaser.Scene {
     this.time.addEvent({
       delay: 400,
       loop: true,
-      callback: () => this.updateHUD(),
+      callback: () => {
+        this.updateHUD();
+        this.updateCooldowns();
+      },
     });
   }
 
@@ -140,7 +146,12 @@ export class HUDScene extends Phaser.Scene {
     }
   }
 
-  private doRoomAction(action: string) {
+  private doRoomAction(action: CareAction) {
+    const now = Date.now();
+    const remaining = (this.cooldownUntil.get(action) ?? 0) - now;
+    if (remaining > 0) return;
+    this.cooldownUntil.set(action, now + ACTION_COOLDOWNS[action]);
+    this.updateCooldowns();
     const activeScenes = this.scene.manager.getScenes(true);
     for (const scene of activeScenes) {
       if (scene !== this && 'doAction' in scene) {
@@ -148,6 +159,13 @@ export class HUDScene extends Phaser.Scene {
         return;
       }
     }
+  }
+
+  private updateCooldowns() {
+    const now = Date.now();
+    this.actionButtons.forEach((button, action) => {
+      button.setCooldown(Math.max(0, (this.cooldownUntil.get(action) ?? 0) - now));
+    });
   }
 
   private navigateRoom(dir: number, rooms: string[]) {

--- a/frontend/src/scenes/RoomScene.ts
+++ b/frontend/src/scenes/RoomScene.ts
@@ -5,6 +5,7 @@ import { wsClient, type BunnyState } from '../network/WebSocketClient';
 import { getDayNightTint, getSeason } from '../utils/time';
 import { getIdentities, type CharacterIdentity } from '../state/identityRegistry';
 import type { LifeStage } from '../config';
+import { isCareAction, type CareAction } from '../game/actions';
 
 const PLAY_AREA_HEIGHT = 480; // Game area above toolbar
 
@@ -101,7 +102,7 @@ export abstract class RoomScene extends Phaser.Scene {
     });
   }
 
-  protected applyAction(action: string, bunnyId: string) {
+  protected applyAction(action: CareAction, bunnyId: string) {
     const b = gameBunnies.find(x => x.id === bunnyId);
     if (!b) return;
 
@@ -116,11 +117,20 @@ export abstract class RoomScene extends Phaser.Scene {
       case 'medicine': b.health = Math.min(100, b.health + 20); break;
     }
 
-    addActivity(`${playerName} ${action === 'feed' ? 'fed' : action === 'clean' ? 'cleaned' : action === 'play' ? 'played with' : action === 'sleep' ? 'put to sleep' : action === 'medicine' ? 'gave medicine to' : 'bred'} ${b.name} ${emojis[action] || ''}`);
+    const verbs: Record<CareAction, string> = {
+      feed: 'fed',
+      clean: 'bathed',
+      play: 'played with',
+      sleep: 'put to sleep',
+      medicine: 'took to the vet',
+      breed: 'bred',
+    };
+    addActivity(`${playerName} ${verbs[action]} ${b.name} ${emojis[action] || ''}`);
     wsClient.sendAction(action, bunnyId);
   }
 
   doAction(action: string) {
+    if (!isCareAction(action)) return;
     if (!selectedBunnyId && gameBunnies.length > 0) {
       selectedBunnyId = gameBunnies[0].id;
     }
@@ -128,7 +138,7 @@ export abstract class RoomScene extends Phaser.Scene {
 
     this.applyAction(action, selectedBunnyId);
 
-    const roomMap: Record<string, string> = {
+    const roomMap: Record<CareAction, string> = {
       feed: 'KitchenScene',
       clean: 'BathroomScene',
       play: 'GardenScene',
@@ -150,7 +160,8 @@ export abstract class RoomScene extends Phaser.Scene {
           case 'feed': bunnyObj.playEating(); this.time.delayedCall(2000, () => bunnyObj.startIdleBounce()); break;
           case 'sleep': bunnyObj.playSleeping(); this.time.delayedCall(3000, () => bunnyObj.startIdleBounce()); break;
           case 'play': bunnyObj.playPlaying(); this.time.delayedCall(2000, () => bunnyObj.startIdleBounce()); break;
-          case 'clean': bunnyObj.playEating(); this.time.delayedCall(1500, () => bunnyObj.startIdleBounce()); break;
+          case 'clean': bunnyObj.playPlaying(); this.time.delayedCall(1500, () => bunnyObj.startIdleBounce()); break;
+          case 'medicine': bunnyObj.playPlaying(); this.time.delayedCall(1500, () => bunnyObj.startIdleBounce()); break;
         }
       }
     }


### PR DESCRIPTION
Fixes #26.

## What changed
- Added a shared frontend care-action config for Feed, Bathe, Play, Sleep, Vet, and Breed.
- Added visible action-button cooldown state with countdown labels and disabled clicks while cooling down.
- Wired the HUD action row to the shared cooldown config.
- Updated room action feedback so Bathe and Vet show an immediate animation hook.
- Kept server-authoritative validation/rate limiting from #28 in place; frontend cooldowns are UX feedback, not trust boundaries.

## Verification
- `npm --prefix frontend run build`
- `npm --prefix backend run build`
