### PR TITLE
Fix #30: Nest polish, action SFX, and persisted mute

### DIFF
--- a/frontend/src/scenes/OnboardingNestScene.ts
+++ b/frontend/src/scenes/OnboardingNestScene.ts
@@ -13,6 +13,7 @@ import {
   type BunnyAssetRef,
   type CharacterIdentity,
 } from '../state/identityRegistry';
+import { playCrack, playEggTap, playHatch } from '../utils/sound';
 
 const PLAY_AREA_HEIGHT = 480;
 
@@ -206,6 +207,8 @@ export class OnboardingNestScene extends Phaser.Scene {
     const egg = recordTap();
     const stage = getCrackStage(egg.taps);
 
+    playEggTap();
+
     // Tap feedback: shake + small squash
     this.tweens.killTweensOf(this.eggContainer);
     this.tweens.add({
@@ -236,7 +239,9 @@ export class OnboardingNestScene extends Phaser.Scene {
     });
 
     if (stage > beforeStage) {
+      playCrack();
       this.refreshCracks(egg.taps, true);
+      this.emitCrackParticles();
     }
     this.refreshProgress(egg.taps);
     this.tapHint.setText(`Taps: ${egg.taps} / ${HATCH_TAPS}`);
@@ -274,19 +279,46 @@ export class OnboardingNestScene extends Phaser.Scene {
     }
   }
 
+
+  private emitCrackParticles() {
+    const cx = this.eggContainer.x;
+    const cy = this.eggContainer.y;
+    for (let i = 0; i < 6; i++) {
+      const chip = this.add.circle(cx, cy, Phaser.Math.Between(2, 4), 0xfff1b8, 0.9).setDepth(6);
+      this.tweens.add({
+        targets: chip,
+        x: cx + Phaser.Math.Between(-44, 44),
+        y: cy + Phaser.Math.Between(-46, 18),
+        alpha: 0,
+        scale: 0.2,
+        duration: Phaser.Math.Between(360, 620),
+        ease: 'Cubic.easeOut',
+        onComplete: () => chip.destroy(),
+      });
+    }
+  }
+
   private startHatch() {
     this.hatching = true;
     this.tapHint.setText('💖 The egg is hatching! 💖');
+    playHatch();
     const baby = performHatch();
 
     this.tweens.killTweensOf(this.eggContainer);
     this.tweens.add({
       targets: this.eggContainer,
       angle: { from: -10, to: 10 },
+      scaleX: { from: 1, to: 1.12 },
+      scaleY: { from: 1, to: 0.9 },
       duration: 80,
       yoyo: true,
       repeat: 8,
-      onComplete: () => this.revealBaby(baby),
+      ease: 'Sine.easeInOut',
+      onComplete: () => {
+        this.eggContainer.setAngle(0);
+        this.eggContainer.setScale(1);
+        this.revealBaby(baby);
+      },
     });
   }
 
@@ -296,6 +328,8 @@ export class OnboardingNestScene extends Phaser.Scene {
 
     // Flash + shrink the eggshell
     const flash = this.add.rectangle(cx, cy, GAME_WIDTH, GAME_HEIGHT, 0xffffff, 0).setDepth(10);
+    this.cameras.main.flash(220, 255, 245, 210);
+    this.cameras.main.shake(160, 0.004);
     this.tweens.add({
       targets: flash, alpha: 0.85, duration: 200, yoyo: true,
       onComplete: () => flash.destroy(),
@@ -346,7 +380,8 @@ export class OnboardingNestScene extends Phaser.Scene {
   }
 
   private handoffToRooms() {
-    this.cameras.main.fadeOut(350);
+    this.tapHint.setText('Welcome home, little bunny!');
+    this.cameras.main.fadeOut(450, 255, 220, 235);
     this.cameras.main.once('camerafadeoutcomplete', () => {
       this.scene.start('LivingRoomScene');
       this.scene.launch('HUDScene');

--- a/frontend/src/scenes/RoomScene.ts
+++ b/frontend/src/scenes/RoomScene.ts
@@ -7,6 +7,7 @@ import { getIdentities, type CharacterIdentity } from '../state/identityRegistry
 import { applyDecay, catchUpNeeds, legacyStatsFromNeeds, NEEDS_BALANCE, normalizeNeeds, readNeedsState, writeNeedsState, type NeedsState } from '../state/needs';
 import type { LifeStage } from '../config';
 import { isCareAction, type CareAction } from '../game/actions';
+import { playBreed, playClean, playFeed, playMedicine, playPlay, playSleep } from '../utils/sound';
 
 const PLAY_AREA_HEIGHT = 480; // Game area above toolbar
 
@@ -152,11 +153,12 @@ export abstract class RoomScene extends Phaser.Scene {
     const emojis: Record<CareAction, string> = { feed: '🍳', clean: '🛁', play: '🎾', sleep: '💤', medicine: '💊', breed: '💕' };
 
     switch (action) {
-      case 'feed': b.hunger = Math.min(100, b.hunger + 25); break;
-      case 'clean': b.cleanliness = Math.min(100, b.cleanliness + 30); break;
-      case 'play': b.happiness = Math.min(100, b.happiness + 20); break;
-      case 'sleep': b.energy = Math.min(100, b.energy + 30); break;
-      case 'medicine': b.health = Math.min(100, b.health + 20); break;
+      case 'feed': b.hunger = Math.min(100, b.hunger + 25); playFeed(); break;
+      case 'clean': b.cleanliness = Math.min(100, b.cleanliness + 30); playClean(); break;
+      case 'play': b.happiness = Math.min(100, b.happiness + 20); playPlay(); break;
+      case 'sleep': b.energy = Math.min(100, b.energy + 30); playSleep(); break;
+      case 'medicine': b.health = Math.min(100, b.health + 20); playMedicine(); break;
+      case 'breed': playBreed(); break;
     }
 
     if ((b.id === 'baby' || b.stage === 'baby') && !isServerBackedBunny(b)) {

--- a/frontend/src/utils/sound.ts
+++ b/frontend/src/utils/sound.ts
@@ -1,6 +1,16 @@
 // Simple Web Audio tone generator for placeholder sounds
 let audioCtx: AudioContext | null = null;
-let muted = false;
+const MUTE_KEY = 'bunny:audio-muted';
+
+let muted = readMutedPreference();
+
+function readMutedPreference(): boolean {
+  try { return window.localStorage.getItem(MUTE_KEY) === 'true'; } catch { return false; }
+}
+
+function writeMutedPreference() {
+  try { window.localStorage.setItem(MUTE_KEY, muted ? 'true' : 'false'); } catch { /* ignore */ }
+}
 
 function getCtx(): AudioContext {
   if (!audioCtx) audioCtx = new AudioContext();
@@ -8,7 +18,7 @@ function getCtx(): AudioContext {
 }
 
 export function isMuted(): boolean { return muted; }
-export function toggleMute(): boolean { muted = !muted; return muted; }
+export function toggleMute(): boolean { muted = !muted; writeMutedPreference(); return muted; }
 
 export function playTone(freq: number, duration: number, type: OscillatorType = 'square', volume = 0.15) {
   if (muted) return;
@@ -35,6 +45,14 @@ export function playMedicine() { playTone(330, 0.15, 'triangle'); }
 export function playBreed() { playTone(440, 0.1, 'sine'); setTimeout(() => playTone(660, 0.15, 'sine'), 120); }
 export function playClick() { playTone(1000, 0.03, 'square', 0.1); }
 export function playAlert() { playTone(440, 0.2); setTimeout(() => playTone(330, 0.3), 200); }
+export function playEggTap() { playTone(392, 0.06, 'triangle', 0.08); setTimeout(() => playTone(523, 0.05, 'triangle', 0.07), 70); }
+export function playCrack() { playTone(180, 0.04, 'sawtooth', 0.07); setTimeout(() => playTone(240, 0.05, 'sawtooth', 0.06), 60); }
+export function playHatch() {
+  playTone(523, 0.12, 'sine', 0.1);
+  setTimeout(() => playTone(659, 0.12, 'sine', 0.1), 120);
+  setTimeout(() => playTone(784, 0.18, 'sine', 0.1), 240);
+  setTimeout(() => playTone(1046, 0.25, 'triangle', 0.08), 380);
+}
 
 // Simple background music loop
 let bgInterval: number | null = null;


### PR DESCRIPTION
## Summary
- adds persisted mute preference for the HUD audio toggle
- adds egg tap/crack/hatch SFX and crack chip particles
- polishes hatch with squash/shake, camera flash/shake, and smoother fade handoff into the room
- adds action SFX hooks for feed/clean/play/sleep/medicine/breed

## Verification
- `npm --prefix frontend run build` ✅

Fixes #30