### PR TITLE
Fix #40: package bunny SVGs into dist

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build && node scripts/copy-bunny-assets.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/frontend/scripts/copy-bunny-assets.mjs
+++ b/frontend/scripts/copy-bunny-assets.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+// Copy frontend/assets/bunnies/** into dist/assets/bunnies/** after vite build.
+// Vite only bundles assets it sees from JS imports; the bunny SVGs are loaded
+// at runtime by Phaser via absolute URLs like `/assets/bunnies/adult/1.svg`,
+// so they must be present in the served `dist/` tree.
+//
+// Uses only Node built-ins so no extra devDependency is added.
+
+import { cp, rm, stat, readdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const frontendRoot = resolve(__dirname, '..');
+const src = resolve(frontendRoot, 'assets', 'bunnies');
+const dest = resolve(frontendRoot, 'dist', 'assets', 'bunnies');
+
+async function exists(path) {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function countFiles(root) {
+  let count = 0;
+  for (const entry of await readdir(root, { withFileTypes: true })) {
+    const child = resolve(root, entry.name);
+    if (entry.isDirectory()) count += await countFiles(child);
+    else if (entry.isFile()) count += 1;
+  }
+  return count;
+}
+
+async function main() {
+  if (!(await exists(src))) {
+    console.error(`[copy-bunny-assets] source not found: ${src}`);
+    process.exit(1);
+  }
+  if (await exists(dest)) {
+    await rm(dest, { recursive: true, force: true });
+  }
+  await cp(src, dest, { recursive: true });
+  const copied = await countFiles(dest);
+  console.log(`[copy-bunny-assets] copied ${copied} file(s) -> ${dest}`);
+}
+
+main().catch((err) => {
+  console.error('[copy-bunny-assets] failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Live game at http://172.20.10.114/ renders a blank navy screen even though `/health` and `/` return 200 (issue #40).
- Root cause: Vite did not copy `frontend/assets/bunnies/**` (400 SVGs) into `frontend/dist/`. Phaser's `BootScene` preloads art via absolute URLs like `/assets/bunnies/adult/1.svg`, but the backend's SPA fallback (`app.get('*')`) returns `index.html` (`text/html`) for every missing asset. Phaser's SVG loader then fails on those responses and the scene never paints the loading bar or transitions, leaving a blank canvas.
- This matches the P0 finding in `docs/qa-review-2026-05-10-2124.md`.

## Changes
- New `frontend/scripts/copy-bunny-assets.mjs` (Node built-ins only).
- `frontend/package.json` build script now runs the copy step after `vite build`.
- After `npm --prefix frontend run build`: `find frontend/dist/assets/bunnies -type f | wc -l` => `400`.

## Closes
Closes #40

## Test plan
- [x] `npm --prefix frontend run build` exits 0
- [x] `dist/assets/bunnies/adult/1.svg`, `adult/100.svg`, `baby/normal/1.svg`, `baby/happy/1.svg`, `baby/sleeping/1.svg` all exist after build
- [x] No source-tree behaviour changes outside the build pipeline
- [ ] Re-deploy and visually verify live `http://172.20.10.114/` renders the startup scene on mobile and desktop viewports (per acceptance criteria — to be done with Jonny's approval before closing the issue)