### PR TITLE
Fix #42: redirect post-hatch users out of onboarding nest + always show HUD

### DIFF
--- a/frontend/src/scenes/OnboardingNestScene.ts
+++ b/frontend/src/scenes/OnboardingNestScene.ts
@@ -7,6 +7,7 @@ import {
   shouldHatch,
   performHatch,
   getIdentities,
+  isHatched,
   HATCH_TAPS,
   assetFor,
   bunnyAssetRef,
@@ -29,6 +30,15 @@ export class OnboardingNestScene extends Phaser.Scene {
   constructor() { super({ key: 'OnboardingNestScene' }); }
 
   create() {
+    // Issue #42: if a returning player lands here after hatch is already
+    // complete, the onboarding egg is non-interactive and there are no room
+    // controls — they get stranded. Redirect into the playable rooms instead.
+    if (isHatched()) {
+      this.scene.start('LivingRoomScene');
+      this.scene.launch('HUDScene');
+      return;
+    }
+
     const { father, mother } = ensureParents();
     this.drawNestBackdrop();
     this.drawParents(father, mother);

--- a/frontend/src/scenes/RoomScene.ts
+++ b/frontend/src/scenes/RoomScene.ts
@@ -74,6 +74,12 @@ export abstract class RoomScene extends Phaser.Scene {
   abstract drawRoom(): void;
 
   create() {
+    // Issue #42: every room must guarantee the HUD is up so a returning player
+    // never lands on a background-only scene without navigation/actions.
+    if (!this.scene.isActive('HUDScene')) {
+      this.scene.launch('HUDScene');
+    }
+
     ensureDemoBunnies();
     this.drawRoom();
 


### PR DESCRIPTION
## Summary
- Fixes #42: returning players landing on `OnboardingNestScene` after hatch were stuck on a background-only scene (the egg ignores taps once `egg.hatched` is true and there is no room HUD), so they couldn't do anything.
- `OnboardingNestScene.create()` now bails out into `LivingRoomScene` + `HUDScene` when `isHatched()` is true, matching the acceptance criterion to redirect to the active room if hatch is complete.
- `RoomScene.create()` now launches `HUDScene` if it is not already active, so every room a returning player navigates into has the side panel (stat bars, action buttons, mute, nav arrows) and the room label visible.

## Why this fixes the reported symptom
Live screenshot shows the pastel hatch/nest background, a central oval/platform, and the HUD toggle perceived as a settings gear — but no bunny and no actions. That matches the post-hatch onboarding-nest dead-end (egg `pointerdown` is a no-op after hatch, no HUDScene is running). The early redirect ensures players never land there, and the HUD safety-launch ensures any other returning-to-a-room path also keeps controls visible.

## Scope (kept narrow)
- Frontend only. No backend, K8s, or asset changes.
- Does not attempt to restore movement/keyboard controls — that is the broader gameplay-restoration work tracked in #44 and the QA regression in #43.

## Test plan
- [x] `npm --prefix frontend run build` passes locally (Vite + tsc + asset copy).
- [ ] Manual: log in as a returning user with a hatched save → land in `LivingRoomScene` with HUD visible.
- [ ] Manual: while hatched, force-navigate to `OnboardingNestScene` (e.g. via dev console `this.scene.start('OnboardingNestScene')`) → immediately redirects to `LivingRoomScene` with HUD.
- [ ] Manual: navigate through every room with HUD arrows on mobile-sized viewport → action buttons / nav arrows / room label remain present in every scene, including Cozy Nest.
- [ ] Live verification on http://172.20.10.114/ after Jonny approval — do not auto-deploy.

Deploy only after Jonny approval per the Bunny workflow.
