### PR TITLE
Fix #44: restore bunny movement (mouse drag + arrow keys)

### DIFF
--- a/frontend/src/objects/Bunny.ts
+++ b/frontend/src/objects/Bunny.ts
@@ -401,6 +401,41 @@ export class Bunny extends Phaser.GameObjects.Container {
     this.head.on('pointerdown', onClick);
   }
 
+  /**
+   * Enable mouse/pointer drag movement. `onMove` fires after each drag step
+   * so the scene can re-clamp position and notify selection state.
+   */
+  setDraggable(onSelect: () => void, onMove?: (x: number, y: number) => void) {
+    const s = this.getStageScale();
+    // Container-level hit area covers head + body so the whole bunny is grabbable.
+    const hitW = 80 * s;
+    const hitH = 130 * s;
+    this.setSize(hitW, hitH);
+    this.setInteractive(new Phaser.Geom.Rectangle(-hitW / 2, -65 * s, hitW, hitH), Phaser.Geom.Rectangle.Contains);
+    (this.scene.input as Phaser.Input.InputPlugin).setDraggable(this);
+
+    this.on('pointerdown', () => onSelect());
+    this.on('dragstart', () => {
+      onSelect();
+      this.stopAnim();
+      this.setScale(1.05);
+    });
+    this.on('drag', (_pointer: Phaser.Input.Pointer, dragX: number, dragY: number) => {
+      this.x = dragX;
+      this.y = dragY;
+      onMove?.(dragX, dragY);
+    });
+    this.on('dragend', () => {
+      this.setScale(1);
+      this.startIdleBounce();
+    });
+  }
+
+  moveBy(dx: number, dy: number) {
+    this.x += dx;
+    this.y += dy;
+  }
+
   destroy(fromScene?: boolean) {
     this.stopAnim();
     super.destroy(fromScene);

--- a/frontend/src/scenes/RoomScene.ts
+++ b/frontend/src/scenes/RoomScene.ts
@@ -11,6 +11,8 @@ import { isCareAction, type CareAction } from '../game/actions';
 import { playBreed, playClean, playFeed, playMedicine, playPlay, playSleep } from '../utils/sound';
 
 const PLAY_AREA_HEIGHT = 480; // Game area above toolbar
+const MOVE_BOUNDS = { minX: 60, maxX: GAME_WIDTH - 60, minY: 120, maxY: PLAY_AREA_HEIGHT - 60 };
+const ARROW_STEP = 14;
 
 // Shared state
 export let gameBunnies: BunnyState[] = [];
@@ -69,6 +71,8 @@ wsClient.onEvent((event) => {
 export abstract class RoomScene extends Phaser.Scene {
   protected bunnyObjects: Bunny[] = [];
   protected dayNightOverlay!: Phaser.GameObjects.Rectangle;
+  protected cursors?: Phaser.Types.Input.Keyboard.CursorKeys;
+  protected wasdKeys?: Record<'W' | 'A' | 'S' | 'D', Phaser.Input.Keyboard.Key>;
 
   abstract getRoomName(): string;
   abstract drawRoom(): void;
@@ -114,7 +118,37 @@ export abstract class RoomScene extends Phaser.Scene {
       },
     });
 
+    this.installKeyboardControls();
     this.cameras.main.fadeIn(350);
+  }
+
+  protected installKeyboardControls() {
+    const kb = this.input.keyboard;
+    if (!kb) return;
+    this.cursors = kb.createCursorKeys();
+    this.wasdKeys = kb.addKeys({
+      W: Phaser.Input.Keyboard.KeyCodes.W,
+      A: Phaser.Input.Keyboard.KeyCodes.A,
+      S: Phaser.Input.Keyboard.KeyCodes.S,
+      D: Phaser.Input.Keyboard.KeyCodes.D,
+    }) as Record<'W' | 'A' | 'S' | 'D', Phaser.Input.Keyboard.Key>;
+  }
+
+  update() {
+    const target = this.bunnyObjects.find(b => b.bunnyId === selectedBunnyId) || this.bunnyObjects[0];
+    if (!target) return;
+    let dx = 0;
+    let dy = 0;
+    const c = this.cursors;
+    const w = this.wasdKeys;
+    if (c?.left?.isDown || w?.A?.isDown) dx -= ARROW_STEP;
+    if (c?.right?.isDown || w?.D?.isDown) dx += ARROW_STEP;
+    if (c?.up?.isDown || w?.W?.isDown) dy -= ARROW_STEP;
+    if (c?.down?.isDown || w?.S?.isDown) dy += ARROW_STEP;
+    if (dx === 0 && dy === 0) return;
+    target.moveBy(dx, dy);
+    target.x = Phaser.Math.Clamp(target.x, MOVE_BOUNDS.minX, MOVE_BOUNDS.maxX);
+    target.y = Phaser.Math.Clamp(target.y, MOVE_BOUNDS.minY, MOVE_BOUNDS.maxY);
   }
 
   protected spawnBunnies() {
@@ -138,12 +172,21 @@ export abstract class RoomScene extends Phaser.Scene {
       const bx = 50 + spacing * (i + 1);
       const bunny = new Bunny(this, bx, groundY, b.id, b.name, b.color, b.stage as LifeStage, identityById[b.id] ?? null);
       bunny.setDepth(3);
-      bunny.setInteractable(() => {
+      const select = () => {
         setSelectedBunny(b.id);
         this.scene.get('HUDScene')?.events.emit('bunnySelected', b.id);
+      };
+      bunny.setDraggable(select, (x, y) => {
+        bunny.x = Phaser.Math.Clamp(x, MOVE_BOUNDS.minX, MOVE_BOUNDS.maxX);
+        bunny.y = Phaser.Math.Clamp(y, MOVE_BOUNDS.minY, MOVE_BOUNDS.maxY);
       });
       this.bunnyObjects.push(bunny);
     });
+
+    // Auto-select first bunny so arrow keys work immediately.
+    if (!selectedBunnyId && alive.length > 0) {
+      setSelectedBunny(alive[0].id);
+    }
   }
 
   protected async applyAction(action: CareAction, bunnyId: string) {


### PR DESCRIPTION
## Summary
Fixes #44 — P0 gameplay regression where bunnies appeared static.

Restores **movement controls** for all bunnies (mother, father, baby):

- **Mouse / touch drag** — every bunny is now draggable via a container-level hit area covering its head + body. Idle bounce pauses during drag and resumes on drop.
- **Arrow keys + WASD** — `RoomScene` reads cursors/WASD per-frame and moves the currently-selected bunny by ~14px/tick, clamped to the play area.
- **Auto-select** — first alive bunny is selected on spawn so keyboard works without an explicit click.
- Movement lives in the `RoomScene` base, so it works in Living Room, Kitchen, Bathroom, Garden, Bedroom, Vet, and Nest scenes identically.

Related issues:
- Linked to #42 (return-to-hatch nest stranding — already fixed on `main`).
- Linked to #43 (full QA regression).

## Files changed
- `frontend/src/objects/Bunny.ts` — `setDraggable(onSelect, onMove)` + `moveBy()` helper.
- `frontend/src/scenes/RoomScene.ts` — `installKeyboardControls()` in `create()`, per-frame `update()` mover, bounds clamp, auto-select first bunny.

## Build gates
- `npm --prefix frontend run build` ✅ (tsc + vite + asset copy: 400 SVGs)
- `npm --prefix backend run build` ✅

## Test plan
- [ ] On `LivingRoomScene` after login + hatch, all three bunnies are visible.
- [ ] Drag father, mother, baby with mouse — they follow the pointer and stay inside the play area.
- [ ] Drag works on mobile/touch viewport.
- [ ] With a bunny selected, arrow keys move it smoothly; WASD also works.
- [ ] Movement works in every room (Living/Kitchen/Bathroom/Garden/Bedroom/Vet/Nest).
- [ ] Refresh page and confirm bunny is still movable.
- [ ] Reverse-navigate back through rooms — no stranded scene; bunnies remain visible and movable.
- [ ] Care actions (feed/sleep/play/etc.) still trigger animations and the HUD cooldown UI.

## Deploy
Do **not** deploy to live before Jonny approves.

Co-Authored-By: Claude Opus 4.7 &lt;noreply@anthropic.com&gt;
