### PR TITLE
Fix #50: redesign Bunny HUD and room dock

### DIFF
--- a/frontend/src/objects/ActionButton.ts
+++ b/frontend/src/objects/ActionButton.ts
@@ -1,38 +1,48 @@
 import Phaser from 'phaser';
 import { playClick } from '../utils/sound';
+import { addIcon, type IconName } from '../ui/Icon';
+import { cssPalette, palette, typography } from '../ui/tokens';
 
 export class ActionButton extends Phaser.GameObjects.Container {
   private bg: Phaser.GameObjects.Rectangle;
+  private icon: Phaser.GameObjects.Image;
   private label: Phaser.GameObjects.Text;
   private cooldownText: Phaser.GameObjects.Text;
+  private cooldownArc: Phaser.GameObjects.Graphics;
   private disabled = false;
   private baseColor: number;
+  private lastRemaining = 0;
+  private maxCooldown = 1;
 
-  constructor(scene: Phaser.Scene, x: number, y: number, text: string, color: number, onClick: () => void, width = 100, height = 44) {
+  constructor(scene: Phaser.Scene, x: number, y: number, text: string, color: number, iconName: IconName, onClick: () => void) {
     super(scene, x, y);
 
     this.baseColor = color;
-    this.bg = scene.add.rectangle(0, 0, width, height, color, 0.92)
-      .setStrokeStyle(2, 0xffffff, 0.25)
+    this.bg = scene.add.rectangle(0, 0, 58, 58, color, 0.96)
+      .setStrokeStyle(2, palette.white, 0.52)
       .setInteractive({ useHandCursor: true });
     this.add(this.bg);
 
-    this.label = scene.add.text(0, 0, text, {
-      fontFamily: 'Nunito, Arial, sans-serif',
-      fontSize: '13px',
-      color: '#ffffff',
-      stroke: '#00000044',
-      strokeThickness: 1,
+    this.icon = addIcon(scene, iconName, 0, -5, 28);
+    this.add(this.icon);
+
+    this.label = scene.add.text(0, 40, text, {
+      fontFamily: typography.families.body,
+      fontSize: '11px',
+      color: cssPalette.plumDeep,
       fontStyle: 'bold',
     }).setOrigin(0.5);
     this.add(this.label);
 
-    this.cooldownText = scene.add.text(0, height / 2 - 10, '', {
-      fontFamily: 'Nunito, Arial, sans-serif',
-      fontSize: '10px',
+    this.cooldownArc = scene.add.graphics();
+    this.add(this.cooldownArc);
+
+    this.cooldownText = scene.add.text(0, -5, '', {
+      fontFamily: typography.families.display,
+      fontSize: '13px',
       color: '#ffffff',
       stroke: '#00000088',
-      strokeThickness: 2,
+      strokeThickness: 3,
       fontStyle: 'bold',
     }).setOrigin(0.5).setVisible(false);
     this.add(this.cooldownText);
@@ -40,42 +50,49 @@ export class ActionButton extends Phaser.GameObjects.Container {
     this.bg.on('pointerover', () => {
       if (this.disabled) return;
       this.bg.setFillStyle(this.baseColor, 1);
-      this.setScale(1.08);
+      this.scene.tweens.add({ targets: this, scale: 1.06, duration: 110, ease: 'Back.easeOut' });
     });
     this.bg.on('pointerout', () => {
       if (this.disabled) return;
-      this.bg.setFillStyle(this.baseColor, 0.92);
-      this.setScale(1);
+      this.bg.setFillStyle(this.baseColor, 0.96);
+      this.scene.tweens.add({ targets: this, scale: 1, duration: 110, ease: 'Sine.easeOut' });
     });
     this.bg.on('pointerdown', () => {
       if (this.disabled) return;
       playClick();
-      this.setScale(0.94);
+      this.scene.tweens.add({ targets: this, scale: 0.94, duration: 70, yoyo: true, ease: 'Sine.easeOut' });
       onClick();
-    });
-    this.bg.on('pointerup', () => {
-      if (!this.disabled) this.setScale(1.08);
     });
 
     scene.add.existing(this);
   }
 
-  setCooldown(remainingMs: number) {
+  setCooldown(remainingMs: number, totalMs = this.maxCooldown) {
+    this.maxCooldown = Math.max(totalMs, remainingMs, 1);
+    this.lastRemaining = remainingMs;
+    this.cooldownArc.clear();
+
     if (remainingMs > 0) {
       this.disabled = true;
       this.bg.disableInteractive();
-      this.bg.setFillStyle(0x555566, 0.72);
+      this.bg.setFillStyle(0x6f637a, 0.78);
       this.setScale(1);
-      this.setAlpha(0.72);
+      this.setAlpha(0.82);
       this.cooldownText.setText(`${Math.ceil(remainingMs / 1000)}s`);
       this.cooldownText.setVisible(true);
+      this.cooldownArc.lineStyle(4, palette.brandPink, 0.95);
+      this.cooldownArc.beginPath();
+      this.cooldownArc.arc(0, 0, 33, -Math.PI / 2, -Math.PI / 2 + (remainingMs / this.maxCooldown) * Math.PI * 2, false);
+      this.cooldownArc.strokePath();
       return;
     }
 
     this.disabled = false;
     this.bg.setInteractive({ useHandCursor: true });
-    this.bg.setFillStyle(this.baseColor, 0.92);
+    this.bg.setFillStyle(this.baseColor, 0.96);
     this.setAlpha(1);
     this.cooldownText.setVisible(false);
   }
+
+  getCooldown() { return this.lastRemaining; }
 }

--- a/frontend/src/objects/StatBar.ts
+++ b/frontend/src/objects/StatBar.ts
@@ -1,43 +1,91 @@
 import Phaser from 'phaser';
+import { addIcon, type IconName } from '../ui/Icon';
+import { cssPalette, palette, radii, typography } from '../ui/tokens';
 
 export class StatBar extends Phaser.GameObjects.Container {
-  private bg: Phaser.GameObjects.Rectangle;
-  private fill: Phaser.GameObjects.Rectangle;
   private label: Phaser.GameObjects.Text;
-  private barWidth: number;
-  private barColor: number;
+  private segments: Phaser.GameObjects.Rectangle[] = [];
+  private alertDot: Phaser.GameObjects.Text;
   private value = 100;
+  private pulseTween?: Phaser.Tweens.Tween;
 
-  constructor(scene: Phaser.Scene, x: number, y: number, labelText: string, color: number, width = 100) {
+  constructor(
+    scene: Phaser.Scene,
+    x: number,
+    y: number,
+    labelText: string,
+    private readonly color: number,
+    private readonly barWidth = 112,
+    icon?: IconName,
+  ) {
     super(scene, x, y);
-    this.barWidth = width;
-    this.barColor = color;
 
-    this.label = scene.add.text(0, 0, labelText, {
-      fontFamily: 'Nunito, Arial, sans-serif',
+    if (icon) {
+      const iconImage = addIcon(scene, icon, 8, 0, 15).setAlpha(0.92);
+      this.add(iconImage);
+    }
+
+    this.label = scene.add.text(22, -9, labelText, {
+      fontFamily: typography.families.body,
       fontSize: '10px',
-      color: '#ffffff',
+      color: cssPalette.plumDeep,
       fontStyle: 'bold',
     }).setOrigin(0, 0.5);
     this.add(this.label);
 
-    this.bg = scene.add.rectangle(50, 0, width, 8, 0x333333, 0.6).setOrigin(0, 0.5);
-    this.bg.setStrokeStyle(1, 0x555555, 0.4);
-    this.add(this.bg);
+    const segmentWidth = (barWidth - 16) / 5;
+    for (let i = 0; i < 5; i += 1) {
+      const shadow = scene.add.rectangle(22 + i * (segmentWidth + 4), 7, segmentWidth, 9, palette.white, 0.42)
+        .setOrigin(0, 0.5)
+        .setStrokeStyle(1, palette.plumDeep, 0.08);
+      this.add(shadow);
 
-    this.fill = scene.add.rectangle(50, 0, width, 8, color).setOrigin(0, 0.5);
-    this.add(this.fill);
+      const segment = scene.add.rectangle(22 + i * (segmentWidth + 4), 7, segmentWidth, 9, color, 0.95)
+        .setOrigin(0, 0.5)
+        .setStrokeStyle(1, palette.white, 0.5);
+      segment.setData('radius', radii.xs);
+      this.segments.push(segment);
+      this.add(segment);
+    }
+
+    this.alertDot = scene.add.text(barWidth + 30, 1, '!', {
+      fontFamily: typography.families.display,
+      fontSize: '12px',
+      color: '#ffffff',
+      backgroundColor: cssPalette.danger,
+      padding: { x: 4, y: 1 },
+      fontStyle: 'bold',
+    }).setOrigin(0.5).setVisible(false);
+    this.add(this.alertDot);
 
     scene.add.existing(this);
   }
 
   setValue(v: number) {
     this.value = Phaser.Math.Clamp(v, 0, 100);
-    this.fill.width = (this.value / 100) * this.barWidth;
-    if (this.value < 20) {
-      this.fill.setFillStyle(0xff3333);
-    } else {
-      this.fill.setFillStyle(this.barColor);
+    const filledSegments = Math.ceil(this.value / 20);
+    this.segments.forEach((segment, index) => {
+      const active = index < filledSegments && this.value > 0;
+      segment.setFillStyle(this.value < 30 ? palette.danger : this.color, active ? 0.96 : 0.16);
+      segment.setStrokeStyle(1, active ? palette.white : palette.plumDeep, active ? 0.55 : 0.15);
+    });
+
+    const danger = this.value < 30;
+    this.alertDot.setVisible(danger);
+    if (danger && !this.pulseTween) {
+      this.pulseTween = this.scene.tweens.add({
+        targets: [...this.segments, this.alertDot],
+        alpha: { from: 0.55, to: 1 },
+        duration: 420,
+        yoyo: true,
+        repeat: -1,
+        ease: 'Sine.easeInOut',
+      });
+    } else if (!danger && this.pulseTween) {
+      this.pulseTween.stop();
+      this.pulseTween = undefined;
+      this.segments.forEach(segment => segment.setAlpha(1));
+      this.alertDot.setAlpha(1);
     }
   }
 

--- a/frontend/src/scenes/HUDScene.ts
+++ b/frontend/src/scenes/HUDScene.ts
@@ -5,7 +5,8 @@ import { ActionButton } from '../objects/ActionButton';
 import { gameBunnies, selectedBunnyId } from './RoomScene';
 import { toggleMute, isMuted } from '../utils/sound';
 import { ACTION_COOLDOWNS, CARE_ACTIONS, type CareAction } from '../game/actions';
-import { addIcon } from '../ui/Icon';
+import { addIcon, type IconName } from '../ui/Icon';
+import { cssPalette, palette, typography } from '../ui/tokens';
 
 const HUD_PREF_KEY = 'bunny:hud-expanded';
 const SIDE_PANEL_WIDTH = 184;
@@ -22,7 +23,8 @@ export class HUDScene extends Phaser.Scene {
   private actionButtons = new Map<CareAction, ActionButton>();
   private cooldownUntil = new Map<CareAction, number>();
   private panel!: Phaser.GameObjects.Container;
-  private panelBg!: Phaser.GameObjects.Rectangle;
+  private panelBg!: Phaser.GameObjects.Graphics;
+  private needDots = new Map<string, Phaser.GameObjects.Text>();
   private toggleBtn!: Phaser.GameObjects.Text;
   private compactSummary!: Phaser.GameObjects.Text;
   private expandedContent!: Phaser.GameObjects.Container;
@@ -64,13 +66,11 @@ export class HUDScene extends Phaser.Scene {
 
   private createSidePanel() {
     this.panel = this.add.container(0, 0).setDepth(50);
-    this.panelBg = this.add.rectangle(0, 0, SIDE_PANEL_WIDTH, PLAY_AREA_HEIGHT - 24, 0x1a1a2e, 0.9)
-      .setOrigin(0, 0)
-      .setStrokeStyle(2, COLORS.accent, 0.55);
+    this.panelBg = this.add.graphics();
     this.panel.add(this.panelBg);
 
     this.toggleBtn = this.add.text(0, 0, '', {
-      fontFamily: 'Nunito, Arial, sans-serif',
+      fontFamily: typography.families.display,
       fontSize: '15px',
       color: '#ffffff',
       backgroundColor: '#ff6b9d',
@@ -85,9 +85,9 @@ export class HUDScene extends Phaser.Scene {
     this.panel.add(this.toggleBtn);
 
     this.compactSummary = this.add.text(0, 0, '🐰\n--', {
-      fontFamily: 'Nunito, Arial, sans-serif',
+      fontFamily: typography.families.body,
       fontSize: '12px',
-      color: '#ffffff',
+      color: cssPalette.plumDeep,
       align: 'center',
       lineSpacing: 7,
     }).setOrigin(0.5, 0);
@@ -97,22 +97,22 @@ export class HUDScene extends Phaser.Scene {
     this.panel.add(this.expandedContent);
 
     this.bunnyNameText = this.add.text(12, 14, 'Select a bunny', {
-      fontFamily: 'Nunito, Arial, sans-serif',
-      fontSize: '13px',
-      color: '#ff6b9d',
+      fontFamily: typography.families.display,
+      fontSize: '15px',
+      color: cssPalette.plumDeep,
       fontStyle: 'bold',
-      wordWrap: { width: SIDE_PANEL_WIDTH - 34 },
+      wordWrap: { width: SIDE_PANEL_WIDTH - 44 },
     });
     this.expandedContent.add(this.bunnyNameText);
 
     const barX = 12;
     const barY = 52;
     this.statBars = {
-      hunger: new StatBar(this, barX, barY, '🍳 Hunger', COLORS.hunger, 92),
-      happiness: new StatBar(this, barX, barY + 24, '😊 Happy', COLORS.happiness, 92),
-      cleanliness: new StatBar(this, barX, barY + 48, '🛁 Clean', COLORS.cleanliness, 92),
-      energy: new StatBar(this, barX, barY + 72, '⚡ Energy', COLORS.energy, 92),
-      health: new StatBar(this, barX, barY + 96, '❤️ Health', COLORS.health, 92),
+      hunger: new StatBar(this, barX, barY, 'Hunger', COLORS.hunger, 102, 'feed'),
+      happiness: new StatBar(this, barX, barY + 30, 'Happy', COLORS.happiness, 102, 'play'),
+      cleanliness: new StatBar(this, barX, barY + 60, 'Clean', COLORS.cleanliness, 102, 'clean'),
+      energy: new StatBar(this, barX, barY + 90, 'Energy', COLORS.energy, 102, 'sleep'),
+      health: new StatBar(this, barX, barY + 120, 'Health', COLORS.health, 102, 'medicine'),
     };
     Object.values(this.statBars).forEach(bar => this.expandedContent.add(bar));
 
@@ -125,16 +125,16 @@ export class HUDScene extends Phaser.Scene {
       breed: COLORS.btnBreed,
     };
     CARE_ACTIONS.forEach((a, i) => {
-      const x = i % 2 === 0 ? 55 : 134;
-      const y = 210 + Math.floor(i / 2) * 42;
-      const btn = new ActionButton(this, x, y, a.label, actionColors[a.action], () => {
+      const x = 38 + (i % 3) * 55;
+      const y = 230 + Math.floor(i / 3) * 83;
+      const btn = new ActionButton(this, x, y, a.shortLabel, actionColors[a.action], a.action as IconName, () => {
         this.doRoomAction(a.action);
-      }, 70, 32);
+      });
       this.actionButtons.set(a.action, btn);
       this.expandedContent.add(btn);
     });
 
-    const initialMuteIcon = addIcon(this, isMuted() ? 'mute' : 'unmute', SIDE_PANEL_WIDTH - 22, PLAY_AREA_HEIGHT - 62, 22)
+    const initialMuteIcon = addIcon(this, isMuted() ? 'mute' : 'unmute', SIDE_PANEL_WIDTH - 24, PLAY_AREA_HEIGHT - 54, 24)
       .setInteractive({ useHandCursor: true });
     this.muteBtn = initialMuteIcon;
     this.muteBtn.on('pointerdown', () => {
@@ -154,8 +154,7 @@ export class HUDScene extends Phaser.Scene {
     const y = this.isMobile && !this.hudExpanded ? SIDE_PANEL_MARGIN + 38 : SIDE_PANEL_MARGIN;
 
     this.panel.setPosition(x, y);
-    this.panelBg.setSize(width, height);
-    this.panelBg.setAlpha(this.hudExpanded ? 0.9 : 0.82);
+    this.drawPanelBg(width, height);
     this.toggleBtn.setPosition(width - 8, 8);
     this.toggleBtn.setText(this.hudExpanded ? '›' : '‹');
     this.compactSummary.setPosition(width / 2, 38);
@@ -163,29 +162,73 @@ export class HUDScene extends Phaser.Scene {
     this.expandedContent.setVisible(this.hudExpanded);
   }
 
+
+  private drawPanelBg(width: number, height: number) {
+    this.panelBg.clear();
+    this.panelBg.fillStyle(palette.plumDeep, 0.18);
+    this.panelBg.fillRoundedRect(4, 6, width, height, 16);
+    this.panelBg.fillStyle(palette.cream, this.hudExpanded ? 0.94 : 0.86);
+    this.panelBg.fillRoundedRect(0, 0, width, height, 16);
+    this.panelBg.lineStyle(1, palette.white, 0.68);
+    this.panelBg.strokeRoundedRect(1, 1, width - 2, height - 2, 15);
+    this.panelBg.lineStyle(2, palette.brandPink, 0.18);
+    this.panelBg.strokeRoundedRect(5, 5, width - 10, height - 10, 12);
+  }
+
   private createNavigation() {
     const rooms = ['LivingRoomScene', 'KitchenScene', 'BathroomScene', 'GardenScene', 'BedroomScene', 'VetScene', 'NestScene'];
-    const arrowY = PLAY_AREA_HEIGHT / 2;
+    const dock = this.add.container(GAME_WIDTH / 2, PLAY_AREA_HEIGHT - 28).setDepth(45);
+    const shadow = this.add.graphics();
+    shadow.fillStyle(palette.plumDeep, 0.16);
+    shadow.fillRoundedRect(-191, -21, 382, 54, 18);
+    dock.add(shadow);
+    const bg = this.add.graphics();
+    bg.fillStyle(palette.cream, 0.92);
+    bg.fillRoundedRect(-191, -27, 382, 54, 18);
+    bg.lineStyle(1, palette.white, 0.7);
+    bg.strokeRoundedRect(-190, -26, 380, 52, 17);
+    dock.add(bg);
 
-    const leftArrow = this.add.text(18, arrowY, '◀', {
-      fontSize: '32px', color: '#ffffff', stroke: '#333', strokeThickness: 3,
-    }).setOrigin(0.5).setInteractive({ useHandCursor: true }).setAlpha(0.7).setDepth(40);
+    const icons: Array<{ room: string; icon: IconName; label: string; need?: string }> = [
+      { room: 'LivingRoomScene', icon: 'play', label: 'Home', need: 'happiness' },
+      { room: 'KitchenScene', icon: 'feed', label: 'Food', need: 'hunger' },
+      { room: 'BathroomScene', icon: 'clean', label: 'Bath', need: 'cleanliness' },
+      { room: 'GardenScene', icon: 'breed', label: 'Yard' },
+      { room: 'BedroomScene', icon: 'sleep', label: 'Sleep', need: 'energy' },
+      { room: 'VetScene', icon: 'medicine', label: 'Vet', need: 'health' },
+      { room: 'NestScene', icon: 'seasonSun', label: 'Nest' },
+    ];
 
-    const rightArrow = this.add.text(GAME_WIDTH - 18, arrowY, '▶', {
-      fontSize: '32px', color: '#ffffff', stroke: '#333', strokeThickness: 3,
-    }).setOrigin(0.5).setInteractive({ useHandCursor: true }).setAlpha(0.7).setDepth(40);
-
-    leftArrow.on('pointerover', () => leftArrow.setAlpha(1));
-    leftArrow.on('pointerout', () => leftArrow.setAlpha(0.7));
-    rightArrow.on('pointerover', () => rightArrow.setAlpha(1));
-    rightArrow.on('pointerout', () => rightArrow.setAlpha(0.7));
-    leftArrow.on('pointerdown', () => this.navigateRoom(-1, rooms));
-    rightArrow.on('pointerdown', () => this.navigateRoom(1, rooms));
+    icons.forEach((item, index) => {
+      const x = -165 + index * 55;
+      const hit = this.add.rectangle(x, -1, 48, 48, palette.white, 0.01)
+        .setInteractive({ useHandCursor: true });
+      const icon = addIcon(this, item.icon, x, -7, 24);
+      const text = this.add.text(x, 17, item.label, {
+        fontFamily: typography.families.body,
+        fontSize: '9px',
+        color: cssPalette.plumDeep,
+        fontStyle: 'bold',
+      }).setOrigin(0.5);
+      const dot = this.add.text(x + 14, -22, '!', {
+        fontFamily: typography.families.display,
+        fontSize: '10px',
+        color: '#ffffff',
+        backgroundColor: cssPalette.danger,
+        padding: { x: 3, y: 0 },
+        fontStyle: 'bold',
+      }).setOrigin(0.5).setVisible(false);
+      if (item.need) this.needDots.set(item.need, dot);
+      hit.on('pointerover', () => icon.setScale(1.14));
+      hit.on('pointerout', () => icon.setScale(1));
+      hit.on('pointerdown', () => this.startRoom(item.room, rooms));
+      dock.add([hit, icon, text, dot]);
+    });
   }
 
   private createRoomLabel() {
     this.roomLabel = this.add.text(GAME_WIDTH / 2, 12, '', {
-      fontFamily: 'Nunito, Arial, sans-serif',
+      fontFamily: typography.families.display,
       fontSize: '16px',
       color: '#ffffff',
       stroke: '#333333',
@@ -197,7 +240,7 @@ export class HUDScene extends Phaser.Scene {
   private updateHUD() {
     const bunny = gameBunnies.find(b => b.id === selectedBunnyId) || gameBunnies.find(b => b.isAlive);
     if (bunny && this.statBars) {
-      this.bunnyNameText.setText(`🐰 ${bunny.name}\n${bunny.stage}`);
+      this.bunnyNameText.setText(`${bunny.name}\n${bunny.stage}`);
       this.statBars.hunger.setValue(bunny.hunger);
       this.statBars.happiness.setValue(bunny.happiness);
       this.statBars.cleanliness.setValue(bunny.cleanliness);
@@ -205,9 +248,11 @@ export class HUDScene extends Phaser.Scene {
       this.statBars.health.setValue(bunny.health);
       const lowest = Math.min(bunny.hunger, bunny.happiness, bunny.cleanliness, bunny.energy, bunny.health);
       this.compactSummary.setText(`🐰\n${Math.round(lowest)}%\nneeds`);
+      this.updateNeedDots(bunny);
     } else {
       this.bunnyNameText.setText('No bunny selected');
       this.compactSummary.setText('🐰\n--');
+      this.updateNeedDots(null);
     }
 
     const rooms = ['LivingRoomScene', 'KitchenScene', 'BathroomScene', 'GardenScene', 'BedroomScene', 'VetScene', 'NestScene'];
@@ -247,8 +292,42 @@ export class HUDScene extends Phaser.Scene {
   private updateCooldowns() {
     const now = Date.now();
     this.actionButtons.forEach((button, action) => {
-      button.setCooldown(Math.max(0, (this.cooldownUntil.get(action) ?? 0) - now));
+      button.setCooldown(Math.max(0, (this.cooldownUntil.get(action) ?? 0) - now), ACTION_COOLDOWNS[action]);
     });
+  }
+
+
+  private updateNeedDots(bunny: any | null) {
+    const values: Record<string, number> = bunny ? {
+      hunger: bunny.hunger,
+      happiness: bunny.happiness,
+      cleanliness: bunny.cleanliness,
+      energy: bunny.energy,
+      health: bunny.health,
+    } : {};
+    this.needDots.forEach((dot, need) => dot.setVisible((values[need] ?? 100) < 30));
+  }
+
+  private startRoom(next: string, rooms: string[]) {
+    const activeScenes = this.scene.manager.getScenes(true);
+    let currentKey = '';
+    for (const scene of activeScenes) {
+      if (scene !== this && rooms.includes(scene.scene.key)) {
+        currentKey = scene.scene.key;
+        break;
+      }
+    }
+    if (currentKey === next) return;
+    const currentScene = currentKey ? this.scene.get(currentKey) : null;
+    if (currentScene) {
+      currentScene.cameras.main.fadeOut(200);
+      currentScene.cameras.main.once('camerafadeoutcomplete', () => {
+        this.scene.stop(currentKey);
+        this.scene.start(next);
+      });
+      return;
+    }
+    this.scene.start(next);
   }
 
   private navigateRoom(dir: number, rooms: string[]) {
@@ -265,7 +344,7 @@ export class HUDScene extends Phaser.Scene {
     const next = rooms[(idx + dir + rooms.length) % rooms.length];
     const currentScene = this.scene.get(currentKey);
     if (currentScene) {
-      currentScene.cameras.main.fadeOut(250);
+      currentScene.cameras.main.fadeOut(200);
       currentScene.cameras.main.once('camerafadeoutcomplete', () => {
         this.scene.stop(currentKey);
         this.scene.start(next);


### PR DESCRIPTION
## Summary
- Replaces the dark side HUD slab with a warm frosted card using the Bunny design tokens.
- Refactors stat bars into segmented, icon-led need meters with low-need pulse/alert indicators.
- Converts care actions into icon-first 58px buttons with cooldown rings.
- Adds a bottom 7-room icon dock with direct navigation and need alert dots.

## Validation
- `npm --prefix frontend run build`
- `npm --prefix backend run build`

Closes #50.