### PR TITLE
Add resilient empty and reconnect states

### DIFF
--- a/frontend/src/network/WebSocketClient.ts
+++ b/frontend/src/network/WebSocketClient.ts
@@ -38,12 +38,14 @@ export interface GameEvent {
 
 type StateCallback = (state: GameState) => void;
 type EventCallback = (event: GameEvent) => void;
+type ConnectionCallback = (connected: boolean) => void;
 
 export class WebSocketClient {
   private ws: WebSocket | null = null;
   private reconnectTimer: number | null = null;
   private stateCallbacks: StateCallback[] = [];
   private eventCallbacks: EventCallback[] = [];
+  private connectionCallbacks: ConnectionCallback[] = [];
   private playerName: string = '';
   private familyId: string = '';
   private playerId: string = '';
@@ -85,6 +87,7 @@ export class WebSocketClient {
       this.ws = new WebSocket(`${WS_URL}?${params}`);
       this.ws.onopen = () => {
         this.connected = true;
+        this.notifyConnection();
         console.log('WebSocket connected');
         if (this.reconnectTimer) {
           clearTimeout(this.reconnectTimer);
@@ -107,10 +110,12 @@ export class WebSocketClient {
       };
       this.ws.onclose = () => {
         this.connected = false;
+        this.notifyConnection();
         this.scheduleReconnect();
       };
       this.ws.onerror = () => {
         this.connected = false;
+        this.notifyConnection();
       };
     } catch {
       this.scheduleReconnect();
@@ -138,6 +143,14 @@ export class WebSocketClient {
 
   onState(cb: StateCallback) { this.stateCallbacks.push(cb); }
   onEvent(cb: EventCallback) { this.eventCallbacks.push(cb); }
+  onConnectionChange(cb: ConnectionCallback) {
+    this.connectionCallbacks.push(cb);
+    cb(this.connected);
+  }
+
+  private notifyConnection() {
+    this.connectionCallbacks.forEach(cb => cb(this.connected));
+  }
 
   isConnected() { return this.connected; }
 

--- a/frontend/src/scenes/OnboardingNestScene.ts
+++ b/frontend/src/scenes/OnboardingNestScene.ts
@@ -28,6 +28,7 @@ export class OnboardingNestScene extends Phaser.Scene {
   private heartMeterMask!: Phaser.GameObjects.Graphics;
   private midHatchHintShown = false;
   private hatching = false;
+  private resumeBanner?: Phaser.GameObjects.Container;
 
   constructor() { super({ key: 'OnboardingNestScene' }); }
 
@@ -47,6 +48,8 @@ export class OnboardingNestScene extends Phaser.Scene {
     this.drawEgg();
     this.drawIntroText();
     this.drawProgress();
+
+    if (getIdentities().egg.taps > 0) this.showResumeCoachMark();
 
     // Restore visible crack progress from any prior session that quit mid-hatch.
     this.refreshCracks(getIdentities().egg.taps);
@@ -278,8 +281,41 @@ export class OnboardingNestScene extends Phaser.Scene {
     this.tweens.add({ targets: this.eggContainer, x: startX + 3, duration: 40, yoyo: true, repeat: 5, onComplete: () => this.eggContainer.setX(startX) });
   }
 
+  private showResumeCoachMark() {
+    const taps = getIdentities().egg.taps;
+    const remaining = Math.max(0, HATCH_TAPS - taps);
+    const banner = this.add.container(GAME_WIDTH / 2, 112).setDepth(12);
+    const bg = this.add.graphics();
+    bg.fillStyle(0xfff6e9, 0.96);
+    bg.fillRoundedRect(-188, -32, 376, 64, 18);
+    bg.lineStyle(2, 0xff6b9d, 0.22);
+    bg.strokeRoundedRect(-186, -30, 372, 60, 16);
+    const text = this.add.text(0, -4, `You're mid-hatch — ${remaining} taps to go!`, {
+      fontFamily: 'Nunito, Arial, sans-serif',
+      fontSize: '16px',
+      color: '#3e1e4f',
+      fontStyle: 'bold',
+    }).setOrigin(0.5);
+    const hint = this.add.text(0, 18, 'Tap the egg when you are ready.', {
+      fontFamily: 'Nunito, Arial, sans-serif',
+      fontSize: '12px',
+      color: '#8a2d52',
+    }).setOrigin(0.5);
+    banner.add([bg, text, hint]);
+    banner.setAlpha(0);
+    this.tweens.add({ targets: banner, alpha: 1, y: 104, duration: 220 });
+    this.resumeBanner = banner;
+    this.time.delayedCall(4200, () => {
+      if (!this.resumeBanner) return;
+      const target = this.resumeBanner;
+      this.resumeBanner = undefined;
+      this.tweens.add({ targets: target, alpha: 0, duration: 350, onComplete: () => target.destroy() });
+    });
+  }
+
   private handleTap() {
     if (this.hatching) return;
+    if (this.resumeBanner) { this.resumeBanner.destroy(); this.resumeBanner = undefined; }
     const beforeStage = getCrackStage();
     const egg = recordTap();
     const stage = getCrackStage(egg.taps);

--- a/frontend/src/scenes/RoomScene.ts
+++ b/frontend/src/scenes/RoomScene.ts
@@ -90,6 +90,10 @@ export abstract class RoomScene extends Phaser.Scene {
   protected dayNightOverlay!: Phaser.GameObjects.Rectangle;
   protected cursors?: Phaser.Types.Input.Keyboard.CursorKeys;
   protected wasdKeys?: Record<'W' | 'A' | 'S' | 'D', Phaser.Input.Keyboard.Key>;
+  private emptyState?: Phaser.GameObjects.Container;
+  private reconnectToast?: Phaser.GameObjects.Container;
+  private fallbackToast?: Phaser.GameObjects.Container;
+  private reconnectTimer?: Phaser.Time.TimerEvent;
 
   abstract getRoomName(): string;
   abstract drawRoom(): void;
@@ -118,6 +122,8 @@ export abstract class RoomScene extends Phaser.Scene {
 
     applyLocalNeedsToBaby();
     this.spawnBunnies();
+    this.scheduleEmptyState();
+    this.installConnectionToast();
 
     this.time.addEvent({
       delay: NEEDS_BALANCE.tickMs,
@@ -217,6 +223,70 @@ export abstract class RoomScene extends Phaser.Scene {
     this.bunnyObjects.forEach(item => item.setSelected(item.bunnyId === selectedBunnyId));
   }
 
+  private scheduleEmptyState() {
+    this.time.delayedCall(1000, () => {
+      if (this.bunnyObjects.length === 0) this.showEmptyState();
+    });
+  }
+
+  private showEmptyState() {
+    if (this.emptyState) return;
+    const box = this.add.container(GAME_WIDTH / 2, 238).setDepth(32);
+    const bg = this.add.graphics();
+    bg.fillStyle(palette.cream, 0.92);
+    bg.fillRoundedRect(-180, -82, 360, 164, 22);
+    bg.lineStyle(2, palette.brandPink, 0.22);
+    bg.strokeRoundedRect(-178, -80, 356, 160, 20);
+    const silhouettes = this.add.text(0, -24, '🐇  🐇  🥚', { fontSize: '42px' }).setOrigin(0.5).setAlpha(0.42);
+    const copy = this.add.text(0, 28, 'Waking your bunnies…', { fontFamily: typography.families.display, fontSize: '20px', color: cssPalette.plumDeep }).setOrigin(0.5);
+    const spinner = this.add.text(0, 62, '✦', { fontSize: '22px', color: cssPalette.brandPink }).setOrigin(0.5);
+    box.add([bg, silhouettes, copy, spinner]);
+    this.tweens.add({ targets: spinner, angle: 360, duration: 1100, repeat: -1, ease: 'Linear' });
+    this.emptyState = box;
+  }
+
+  private installConnectionToast() {
+    wsClient.onConnectionChange((connected) => {
+      if (connected) {
+        this.reconnectTimer?.remove(false);
+        this.reconnectTimer = undefined;
+        this.hideReconnectToast();
+        return;
+      }
+      if (this.reconnectToast || this.reconnectTimer) return;
+      this.reconnectTimer = this.time.delayedCall(2000, () => this.showReconnectToast());
+    });
+  }
+
+  private showReconnectToast() {
+    if (this.reconnectToast) return;
+    const toast = this.add.container(GAME_WIDTH / 2, 18).setDepth(80);
+    const bg = this.add.rectangle(0, 0, GAME_WIDTH - 80, 28, palette.butter, 0.92).setStrokeStyle(1, palette.plumDeep, 0.18);
+    const text = this.add.text(0, 0, 'Reconnecting… changes are safe locally', { fontFamily: typography.families.body, fontSize: '13px', color: cssPalette.plumDeep, fontStyle: 'bold' }).setOrigin(0.5);
+    toast.add([bg, text]);
+    toast.setAlpha(0);
+    this.tweens.add({ targets: toast, alpha: 1, y: 24, duration: 180 });
+    this.reconnectToast = toast;
+  }
+
+  private hideReconnectToast() {
+    if (!this.reconnectToast) return;
+    const toast = this.reconnectToast;
+    this.reconnectToast = undefined;
+    this.tweens.add({ targets: toast, alpha: 0, y: 12, duration: 180, onComplete: () => toast.destroy() });
+  }
+
+  private showFallbackToast() {
+    if (this.fallbackToast) this.fallbackToast.destroy();
+    const toast = this.add.container(GAME_WIDTH / 2, PLAY_AREA_HEIGHT - 84).setDepth(82);
+    const bg = this.add.rectangle(0, 0, 330, 34, palette.plumDeep, 0.86);
+    const text = this.add.text(0, 0, 'Saved locally — syncing when connected', { fontFamily: typography.families.body, fontSize: '13px', color: cssPalette.white, fontStyle: 'bold' }).setOrigin(0.5);
+    toast.add([bg, text]);
+    toast.setAlpha(0);
+    this.tweens.add({ targets: toast, alpha: 1, y: toast.y - 8, duration: 180, yoyo: true, hold: 1700, onComplete: () => { toast.destroy(); if (this.fallbackToast === toast) this.fallbackToast = undefined; } });
+    this.fallbackToast = toast;
+  }
+
   protected async applyAction(action: CareAction, bunnyId: string) {
     const b = gameBunnies.find(x => x.id === bunnyId);
     if (!b) return;
@@ -242,8 +312,13 @@ export abstract class RoomScene extends Phaser.Scene {
 
     const serverActionMap: Partial<Record<CareAction, SaveCareAction>> = { feed: 'feed', clean: 'bathe', play: 'play', sleep: 'sleep', medicine: 'vet' };
     const serverAction = serverActionMap[action];
+    let usedLocalFallback = false;
     const serverSave = serverAction
-      ? await saveClient.applyAction(serverAction).catch((err: unknown) => { console.warn('Server action failed, using local fallback', err); return null; })
+      ? await saveClient.applyAction(serverAction).catch((err: unknown) => {
+        console.warn('Server action failed, using local fallback', err);
+        usedLocalFallback = true;
+        return null;
+      })
       : null;
 
     if (serverSave) {
@@ -253,6 +328,7 @@ export abstract class RoomScene extends Phaser.Scene {
       b.energy = serverSave.needs.energy;
       b.health = serverSave.needs.health;
     } else {
+      if (usedLocalFallback) this.showFallbackToast();
       switch (action) {
         case 'feed': b.hunger = Math.min(100, b.hunger + 25); break;
         case 'clean': b.cleanliness = Math.min(100, b.cleanliness + 30); break;


### PR DESCRIPTION
## Summary
- Adds empty/loading bunny state after a quiet 1s load window.
- Adds WebSocket connection-change callbacks and a delayed reconnect toast.
- Adds local fallback save toast when server actions fail.
- Adds mid-hatch resume coach mark for first-run onboarding.

## Test
- npm --prefix frontend run build

Fixes #56.
