### PR TITLE
Improve Bunny Game canvas accessibility

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,6 +17,17 @@
     }
     #game-container { position: relative; }
     canvas { display: block; }
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
   </style>
 
     <style>
@@ -25,7 +36,8 @@
     </style>
   </head>
 <body>
-  <div id="game-container"></div>
+  <div id="sr-status" class="sr-only" aria-live="polite" aria-atomic="true">Bunny Game loading</div>
+  <div id="game-container" role="application" aria-label="Bunny Game canvas. Use Tab to cycle bunnies, brackets to change rooms, number keys for actions, and question mark for help."></div>
   <script type="module" src="/src/main.ts"></script>
 </body>
 </html>

--- a/frontend/src/objects/ActionButton.ts
+++ b/frontend/src/objects/ActionButton.ts
@@ -2,6 +2,7 @@ import Phaser from 'phaser';
 import { playClick } from '../utils/sound';
 import { addIcon, type IconName } from '../ui/Icon';
 import { cssPalette, palette, typography } from '../ui/tokens';
+import { motionDuration } from '../utils/accessibility';
 
 export class ActionButton extends Phaser.GameObjects.Container {
   private bg: Phaser.GameObjects.Rectangle;
@@ -19,7 +20,7 @@ export class ActionButton extends Phaser.GameObjects.Container {
 
     this.baseColor = color;
     this.bg = scene.add.rectangle(0, 0, 58, 58, color, 0.96)
-      .setStrokeStyle(2, palette.white, 0.52)
+      .setStrokeStyle(3, palette.plumDeep, 0.72)
       .setInteractive({ useHandCursor: true });
     this.add(this.bg);
 
@@ -29,7 +30,7 @@ export class ActionButton extends Phaser.GameObjects.Container {
     this.label = scene.add.text(0, 40, text, {
       fontFamily: typography.families.body,
       fontSize: '11px',
-      color: cssPalette.plumDeep,
+      color: '#201832',
       fontStyle: 'bold',
     }).setOrigin(0.5);
     this.add(this.label);
@@ -50,17 +51,17 @@ export class ActionButton extends Phaser.GameObjects.Container {
     this.bg.on('pointerover', () => {
       if (this.disabled) return;
       this.bg.setFillStyle(this.baseColor, 1);
-      this.scene.tweens.add({ targets: this, scale: 1.06, duration: 110, ease: 'Back.easeOut' });
+      this.scene.tweens.add({ targets: this, scale: 1.06, duration: motionDuration(110), ease: 'Back.easeOut' });
     });
     this.bg.on('pointerout', () => {
       if (this.disabled) return;
       this.bg.setFillStyle(this.baseColor, 0.96);
-      this.scene.tweens.add({ targets: this, scale: 1, duration: 110, ease: 'Sine.easeOut' });
+      this.scene.tweens.add({ targets: this, scale: 1, duration: motionDuration(110), ease: 'Sine.easeOut' });
     });
     this.bg.on('pointerdown', () => {
       if (this.disabled) return;
       playClick();
-      this.scene.tweens.add({ targets: this, scale: 0.94, duration: 70, yoyo: true, ease: 'Sine.easeOut' });
+      this.scene.tweens.add({ targets: this, scale: 0.94, duration: motionDuration(70), yoyo: true, ease: 'Sine.easeOut' });
       onClick();
     });
 

--- a/frontend/src/objects/Bunny.ts
+++ b/frontend/src/objects/Bunny.ts
@@ -2,6 +2,7 @@ import Phaser from 'phaser';
 import { BUNNY_COLORS, type LifeStage } from '../config';
 import { cssPalette, palette, typography } from '../ui/tokens';
 import { assetFor, bunnyAssetRef, type BunnyAssetRef, type CharacterIdentity, type CharacterState } from '../state/identityRegistry';
+import { prefersReducedMotion, motionDuration } from '../utils/accessibility';
 
 export class Bunny extends Phaser.GameObjects.Container {
   private bodyShape: Phaser.GameObjects.Ellipse;
@@ -273,6 +274,7 @@ export class Bunny extends Phaser.GameObjects.Container {
     this.stopAnim();
     const idleAsset = this.getIdleAssetRef();
     if (idleAsset) this.showSpriteAsset(idleAsset);
+    if (prefersReducedMotion()) return;
     this.bounceTimer = this.scene.time.addEvent({
       delay: 1200,
       loop: true,
@@ -280,7 +282,7 @@ export class Bunny extends Phaser.GameObjects.Container {
         this.scene.tweens.add({
           targets: this,
           y: this.y - 8,
-          duration: 400,
+          duration: motionDuration(400),
           yoyo: true,
           ease: 'Sine.easeInOut',
         });
@@ -300,7 +302,7 @@ export class Bunny extends Phaser.GameObjects.Container {
           targets: this,
           scaleX: 1.06,
           scaleY: 0.94,
-          duration: 150,
+          duration: motionDuration(150),
           yoyo: true,
           ease: 'Sine.easeInOut',
         });
@@ -319,7 +321,7 @@ export class Bunny extends Phaser.GameObjects.Container {
           targets: spriteAsset,
           scaleX: spriteAsset.scaleX * 1.03,
           scaleY: spriteAsset.scaleY * 1.03,
-          duration: 1300,
+          duration: motionDuration(1300),
           yoyo: true,
           repeat: -1,
           ease: 'Sine.easeInOut',
@@ -336,8 +338,8 @@ export class Bunny extends Phaser.GameObjects.Container {
       targets: this.zzz,
       y: -100,
       alpha: 0,
-      duration: 2000,
-      repeat: -1,
+      duration: motionDuration(2000),
+      repeat: prefersReducedMotion() ? 0 : -1,
       onRepeat: () => { if (this.zzz) { this.zzz.y = -60; this.zzz.alpha = 1; } },
     });
   }
@@ -354,7 +356,7 @@ export class Bunny extends Phaser.GameObjects.Container {
           targets: this,
           y: this.y - 25,
           angle: Phaser.Math.Between(-12, 12),
-          duration: 250,
+          duration: motionDuration(250),
           yoyo: true,
           ease: 'Back.easeOut',
         });
@@ -379,7 +381,7 @@ export class Bunny extends Phaser.GameObjects.Container {
       y: text.y - 46,
       alpha: 0,
       scale: { from: 1.08, to: 0.86 },
-      duration: 1200,
+      duration: motionDuration(1200),
       ease: 'Cubic.easeOut',
       onComplete: () => text.destroy(),
     });
@@ -389,7 +391,8 @@ export class Bunny extends Phaser.GameObjects.Container {
     this.stopAnim();
     this.animState = 'bathing';
     this.showSpriteAsset(this.getAssetRef(this.getRole() === 'baby' ? 'playing' : 'normal'));
-    for (let i = 0; i < 7; i++) {
+    const bubbleCount = prefersReducedMotion() ? 1 : 7;
+    for (let i = 0; i < bubbleCount; i++) {
       const bubble = this.scene.add.circle(Phaser.Math.Between(-28, 28), Phaser.Math.Between(-8, 42), Phaser.Math.Between(4, 9), palette.sky, 0.44);
       bubble.setStrokeStyle(1, palette.white, 0.65);
       this.actionProps.push(bubble);
@@ -400,9 +403,9 @@ export class Bunny extends Phaser.GameObjects.Container {
         y: bubble.y - Phaser.Math.Between(36, 70),
         alpha: 0,
         scale: 1.45,
-        duration: Phaser.Math.Between(850, 1350),
-        repeat: -1,
-        delay: i * 90,
+        duration: motionDuration(Phaser.Math.Between(850, 1350)),
+        repeat: prefersReducedMotion() ? 0 : -1,
+        delay: prefersReducedMotion() ? 0 : i * 90,
         ease: 'Sine.easeOut',
       });
     }
@@ -410,7 +413,7 @@ export class Bunny extends Phaser.GameObjects.Container {
       delay: 420,
       loop: true,
       callback: () => {
-        this.scene.tweens.add({ targets: this, angle: { from: -4, to: 4 }, duration: 210, yoyo: true, ease: 'Sine.easeInOut' });
+        this.scene.tweens.add({ targets: this, angle: { from: -4, to: 4 }, duration: motionDuration(210), yoyo: true, ease: 'Sine.easeInOut' });
       },
     });
   }
@@ -429,13 +432,13 @@ export class Bunny extends Phaser.GameObjects.Container {
     }).setOrigin(0.5);
     this.actionProps.push(heart, cross);
     this.add([heart, cross]);
-    this.scene.tweens.add({ targets: heart, y: -105, alpha: 0.2, scale: 1.25, duration: 900, yoyo: true, repeat: -1, ease: 'Sine.easeInOut' });
-    this.scene.tweens.add({ targets: cross, angle: 360, duration: 1600, repeat: -1, ease: 'Linear' });
+    this.scene.tweens.add({ targets: heart, y: -105, alpha: 0.2, scale: 1.25, duration: motionDuration(900), yoyo: true, repeat: -1, ease: 'Sine.easeInOut' });
+    this.scene.tweens.add({ targets: cross, angle: 360, duration: motionDuration(1600), repeat: -1, ease: 'Linear' });
     this.bounceTimer = this.scene.time.addEvent({
       delay: 650,
       loop: true,
       callback: () => {
-        this.scene.tweens.add({ targets: this, scaleX: 1.03, scaleY: 0.97, duration: 240, yoyo: true, ease: 'Sine.easeInOut' });
+        this.scene.tweens.add({ targets: this, scaleX: 1.03, scaleY: 0.97, duration: motionDuration(240), yoyo: true, ease: 'Sine.easeInOut' });
       },
     });
   }
@@ -454,8 +457,8 @@ export class Bunny extends Phaser.GameObjects.Container {
     this.stopAnim();
     this.animState = 'sad';
     this.mouth.setAngle(180);
-    this.scene.tweens.add({ targets: this.leftEar, angle: -25, duration: 500 });
-    this.scene.tweens.add({ targets: this.rightEar, angle: 25, duration: 500 });
+    this.scene.tweens.add({ targets: this.leftEar, angle: -25, duration: motionDuration(500) });
+    this.scene.tweens.add({ targets: this.rightEar, angle: 25, duration: motionDuration(500) });
   }
 
   playSick() {
@@ -465,7 +468,7 @@ export class Bunny extends Phaser.GameObjects.Container {
     this.scene.tweens.add({
       targets: this,
       angle: { from: -3, to: 3 },
-      duration: 200,
+      duration: motionDuration(200),
       repeat: -1,
       yoyo: true,
     });
@@ -566,12 +569,13 @@ export class Bunny extends Phaser.GameObjects.Container {
     this.scene.tweens.killTweensOf(this.selectionRing);
     if (selected) {
       this.selectionRing.setAlpha(0.95);
+      if (prefersReducedMotion()) return;
       this.scene.tweens.add({
         targets: this.selectionRing,
         scaleX: 1.12,
         scaleY: 1.18,
         alpha: 0.42,
-        duration: 720,
+        duration: motionDuration(720),
         yoyo: true,
         repeat: -1,
         ease: 'Sine.easeInOut',

--- a/frontend/src/objects/StatBar.ts
+++ b/frontend/src/objects/StatBar.ts
@@ -1,6 +1,7 @@
 import Phaser from 'phaser';
 import { addIcon, type IconName } from '../ui/Icon';
 import { cssPalette, palette, radii, typography } from '../ui/tokens';
+import { motionDuration } from '../utils/accessibility';
 
 export class StatBar extends Phaser.GameObjects.Container {
   private label: Phaser.GameObjects.Text;
@@ -28,7 +29,7 @@ export class StatBar extends Phaser.GameObjects.Container {
     this.label = scene.add.text(22, -9, labelText, {
       fontFamily: typography.families.body,
       fontSize: '10px',
-      color: cssPalette.plumDeep,
+      color: '#201832',
       fontStyle: 'bold',
     }).setOrigin(0, 0.5);
     this.add(this.label);
@@ -76,7 +77,7 @@ export class StatBar extends Phaser.GameObjects.Container {
       this.pulseTween = this.scene.tweens.add({
         targets: [...this.segments, this.alertDot],
         alpha: { from: 0.55, to: 1 },
-        duration: 420,
+        duration: motionDuration(420),
         yoyo: true,
         repeat: -1,
         ease: 'Sine.easeInOut',

--- a/frontend/src/scenes/BathroomScene.ts
+++ b/frontend/src/scenes/BathroomScene.ts
@@ -1,6 +1,7 @@
 import Phaser from 'phaser';
 import { GAME_WIDTH } from '../config';
 import { RoomScene } from './RoomScene';
+import { prefersReducedMotion } from '../utils/accessibility';
 
 const H = 480;
 
@@ -17,8 +18,8 @@ export class BathroomScene extends RoomScene {
     super.create();
     this.bunnyObjects.forEach(b => {
       b.playBathing();
-      this.playRoomActionFlair('clean', b);
-      this.time.delayedCall(2200, () => b.startIdleBounce());
+      if (!prefersReducedMotion()) this.playRoomActionFlair('clean', b);
+      this.time.delayedCall(prefersReducedMotion() ? 300 : 2200, () => b.startIdleBounce());
     });
   }
 }

--- a/frontend/src/scenes/BedroomScene.ts
+++ b/frontend/src/scenes/BedroomScene.ts
@@ -1,6 +1,7 @@
 import Phaser from 'phaser';
 import { GAME_WIDTH } from '../config';
 import { RoomScene } from './RoomScene';
+import { prefersReducedMotion } from '../utils/accessibility';
 
 const H = 480;
 
@@ -16,7 +17,7 @@ export class BedroomScene extends RoomScene {
     super.create();
     this.bunnyObjects.forEach(b => {
       b.playSleeping();
-      this.time.delayedCall(5000, () => b.startIdleBounce());
+      this.time.delayedCall(prefersReducedMotion() ? 300 : 5000, () => b.startIdleBounce());
     });
   }
 }

--- a/frontend/src/scenes/GardenScene.ts
+++ b/frontend/src/scenes/GardenScene.ts
@@ -1,6 +1,7 @@
 import Phaser from 'phaser';
 import { GAME_WIDTH } from '../config';
 import { RoomScene } from './RoomScene';
+import { prefersReducedMotion } from '../utils/accessibility';
 
 const H = 480;
 
@@ -16,8 +17,8 @@ export class GardenScene extends RoomScene {
     super.create();
     this.bunnyObjects.forEach(b => {
       b.playPlaying();
-      this.playRoomActionFlair('play', b);
-      this.time.delayedCall(3000, () => b.startIdleBounce());
+      if (!prefersReducedMotion()) this.playRoomActionFlair('play', b);
+      this.time.delayedCall(prefersReducedMotion() ? 300 : 3000, () => b.startIdleBounce());
     });
   }
 }

--- a/frontend/src/scenes/HUDScene.ts
+++ b/frontend/src/scenes/HUDScene.ts
@@ -7,6 +7,7 @@ import { cycleVolume, getVolume, getVolumeLabel } from '../utils/sound';
 import { ACTION_COOLDOWNS, CARE_ACTIONS, type CareAction } from '../game/actions';
 import { addIcon, type IconName } from '../ui/Icon';
 import { cssPalette, palette, typography } from '../ui/tokens';
+import { announce, motionDuration } from '../utils/accessibility';
 
 const HUD_PREF_KEY = 'bunny:hud-expanded';
 const SIDE_PANEL_WIDTH = 184;
@@ -31,6 +32,10 @@ export class HUDScene extends Phaser.Scene {
   private expandedContent!: Phaser.GameObjects.Container;
   private hudExpanded = true;
   private isMobile = false;
+  private keyboardMode = false;
+  private helpPanel?: Phaser.GameObjects.Container;
+  private focusOutline?: Phaser.GameObjects.Rectangle;
+  private focusedButton = 0;
 
   constructor() { super({ key: 'HUDScene' }); }
 
@@ -41,6 +46,7 @@ export class HUDScene extends Phaser.Scene {
     this.createSidePanel();
     this.createNavigation();
     this.createRoomLabel();
+    this.installKeyboardShortcuts();
 
     this.scale.on('resize', () => this.layoutPanel());
 
@@ -328,9 +334,10 @@ export class HUDScene extends Phaser.Scene {
       }
     }
     if (currentKey === next) return;
+    announce(`Entered ${this.roomAnnouncement(next)}`);
     const currentScene = currentKey ? this.scene.get(currentKey) : null;
     if (currentScene) {
-      currentScene.cameras.main.fadeOut(200);
+      currentScene.cameras.main.fadeOut(motionDuration(200));
       currentScene.cameras.main.once('camerafadeoutcomplete', () => {
         this.scene.stop(currentKey);
         this.scene.start(next);
@@ -354,12 +361,100 @@ export class HUDScene extends Phaser.Scene {
     const next = rooms[(idx + dir + rooms.length) % rooms.length];
     const currentScene = this.scene.get(currentKey);
     if (currentScene) {
-      currentScene.cameras.main.fadeOut(200);
+      currentScene.cameras.main.fadeOut(motionDuration(200));
       currentScene.cameras.main.once('camerafadeoutcomplete', () => {
         this.scene.stop(currentKey);
         this.scene.start(next);
       });
     }
+  }
+
+  private installKeyboardShortcuts() {
+    const kb = this.input.keyboard;
+    if (!kb) return;
+    kb.on('keydown-TAB', (event: KeyboardEvent) => {
+      event.preventDefault();
+      this.keyboardMode = true;
+      this.focusedButton = (this.focusedButton + 1) % CARE_ACTIONS.length;
+      this.drawFocusOutline();
+      const activeRoom = this.getActiveRoomScene();
+      if (activeRoom && 'selectNextBunny' in activeRoom) (activeRoom as any).selectNextBunny();
+    });
+    kb.on('keydown', (event: KeyboardEvent) => {
+      if (event.key === '[') this.cycleActiveRoom(-1);
+      if (event.key === ']') this.cycleActiveRoom(1);
+      if (event.key === '?') this.toggleHelpPanel();
+    });
+    CARE_ACTIONS.forEach((action, index) => {
+      kb.on(`keydown-${index + 1}`, () => {
+        this.keyboardMode = true;
+        this.focusedButton = index;
+        this.drawFocusOutline();
+        this.doRoomAction(action.action);
+      });
+    });
+  }
+
+  private getActiveRoomScene(): Phaser.Scene | null {
+    const rooms = ['LivingRoomScene', 'KitchenScene', 'BathroomScene', 'GardenScene', 'BedroomScene', 'VetScene', 'NestScene'];
+    return this.scene.manager.getScenes(true).find(scene => scene !== this && rooms.includes(scene.scene.key)) ?? null;
+  }
+
+  private cycleActiveRoom(dir: number) {
+    const active = this.getActiveRoomScene();
+    if (active && 'cycleRoom' in active) (active as any).cycleRoom(dir);
+  }
+
+  private roomAnnouncement(sceneKey: string): string {
+    const names: Record<string, string> = {
+      LivingRoomScene: 'Living Room', KitchenScene: 'Kitchen', BathroomScene: 'Bathroom',
+      GardenScene: 'Garden', BedroomScene: 'Bedroom', VetScene: 'Vet Office', NestScene: 'Cozy Nest',
+    };
+    return names[sceneKey] || sceneKey;
+  }
+
+  private drawFocusOutline() {
+    this.focusOutline?.destroy();
+    if (!this.keyboardMode || !this.hudExpanded) return;
+    const action = CARE_ACTIONS[this.focusedButton]?.action;
+    const button = action ? this.actionButtons.get(action) : null;
+    if (!button) return;
+    this.focusOutline = this.add.rectangle(this.panel.x + this.expandedContent.x + button.x, this.panel.y + this.expandedContent.y + button.y, 68, 68)
+      .setStrokeStyle(4, palette.plumDeep, 0.95)
+      .setDepth(95);
+    announce(`Focused ${CARE_ACTIONS[this.focusedButton].label}. Press ${this.focusedButton + 1} to use.`);
+  }
+
+  private toggleHelpPanel() {
+    if (this.helpPanel) {
+      this.helpPanel.destroy();
+      this.helpPanel = undefined;
+      announce('Keyboard shortcuts closed');
+      return;
+    }
+    const panel = this.add.container(GAME_WIDTH / 2, 250).setDepth(100);
+    const bg = this.add.rectangle(0, 0, 430, 250, palette.cream, 0.97)
+      .setStrokeStyle(3, palette.plumDeep, 0.9);
+    const copy = [
+      'Keyboard shortcuts',
+      'Tab: select next bunny',
+      '[ / ]: previous / next room',
+      '1 Feed  2 Clean  3 Play',
+      '4 Sleep  5 Vet  6 Breed',
+      'Arrow keys or WASD: move selected bunny',
+      '?: close this help panel',
+    ].join('\n');
+    const text = this.add.text(0, 0, copy, {
+      fontFamily: typography.families.body,
+      fontSize: '18px',
+      color: cssPalette.plumDeep,
+      align: 'center',
+      lineSpacing: 8,
+      fontStyle: 'bold',
+    }).setOrigin(0.5);
+    panel.add([bg, text]);
+    this.helpPanel = panel;
+    announce('Keyboard shortcuts opened. Tab selects bunnies, brackets change rooms, one through six trigger actions.');
   }
 }
 

--- a/frontend/src/scenes/KitchenScene.ts
+++ b/frontend/src/scenes/KitchenScene.ts
@@ -1,6 +1,7 @@
 import Phaser from 'phaser';
 import { GAME_WIDTH } from '../config';
 import { RoomScene } from './RoomScene';
+import { prefersReducedMotion } from '../utils/accessibility';
 
 const H = 480;
 
@@ -16,8 +17,8 @@ export class KitchenScene extends RoomScene {
     super.create();
     this.bunnyObjects.forEach(b => {
       b.playEating();
-      this.playRoomActionFlair('feed', b);
-      this.time.delayedCall(3000, () => b.startIdleBounce());
+      if (!prefersReducedMotion()) this.playRoomActionFlair('feed', b);
+      this.time.delayedCall(prefersReducedMotion() ? 300 : 3000, () => b.startIdleBounce());
     });
   }
 }

--- a/frontend/src/scenes/LivingRoomScene.ts
+++ b/frontend/src/scenes/LivingRoomScene.ts
@@ -1,6 +1,7 @@
 import Phaser from 'phaser';
 import { GAME_WIDTH } from '../config';
 import { RoomScene } from './RoomScene';
+import { motionDuration, prefersReducedMotion } from '../utils/accessibility';
 
 const H = 480; // play area height
 
@@ -16,7 +17,7 @@ export class LivingRoomScene extends RoomScene {
 
   drawRoom() {
     this.add.image(GAME_WIDTH / 2, H / 2, 'room-living').setDisplaySize(GAME_WIDTH, H);
-    if (this.enterWithCurtainWipe) this.playCurtainOpen();
+    if (this.enterWithCurtainWipe && !prefersReducedMotion()) this.playCurtainOpen();
   }
 
   private playCurtainOpen() {
@@ -25,7 +26,7 @@ export class LivingRoomScene extends RoomScene {
     this.tweens.add({
       targets: [curtain, glint],
       x: GAME_WIDTH + GAME_WIDTH / 2,
-      duration: 420,
+      duration: motionDuration(420),
       ease: 'Sine.easeInOut',
       onComplete: () => curtain.destroy(),
     });

--- a/frontend/src/scenes/RoomScene.ts
+++ b/frontend/src/scenes/RoomScene.ts
@@ -11,10 +11,12 @@ import { isCareAction, type CareAction } from '../game/actions';
 import { playBreed, playClean, playFeed, playMedicine, playPlay, playSleep } from '../utils/sound';
 import { playSample } from '../utils/sampleAudio';
 import { needColors, palette, typography, cssPalette } from '../ui/tokens';
+import { announce, motionDuration, prefersReducedMotion } from '../utils/accessibility';
 
 const PLAY_AREA_HEIGHT = 480; // Game area above toolbar
 const MOVE_BOUNDS = { minX: 60, maxX: GAME_WIDTH - 60, minY: 120, maxY: PLAY_AREA_HEIGHT - 60 };
 const ARROW_STEP = 14;
+const ROOM_SEQUENCE = ['LivingRoomScene', 'KitchenScene', 'BathroomScene', 'GardenScene', 'BedroomScene', 'VetScene', 'NestScene'];
 
 type StatKey = 'hunger' | 'energy' | 'happiness' | 'cleanliness' | 'health';
 const ACTION_STAT: Partial<Record<CareAction, StatKey>> = {
@@ -149,7 +151,8 @@ export abstract class RoomScene extends Phaser.Scene {
     });
 
     this.installKeyboardControls();
-    this.cameras.main.fadeIn(350);
+    this.cameras.main.fadeIn(motionDuration(350));
+    announce(`Entered ${this.getRoomName().replace(/^[^A-Za-z]+\s*/, '')}`);
   }
 
   protected installKeyboardControls() {
@@ -208,6 +211,7 @@ export abstract class RoomScene extends Phaser.Scene {
       const select = () => {
         setSelectedBunny(b.id);
         refreshSelectionRings();
+        announce(`Selected ${b.name}`);
         this.scene.get('HUDScene')?.events.emit('bunnySelected', b.id);
       };
       bunny.setDraggable(select, (x, y) => {
@@ -242,7 +246,7 @@ export abstract class RoomScene extends Phaser.Scene {
     const copy = this.add.text(0, 28, 'Waking your bunnies…', { fontFamily: typography.families.display, fontSize: '20px', color: cssPalette.plumDeep }).setOrigin(0.5);
     const spinner = this.add.text(0, 62, '✦', { fontSize: '22px', color: cssPalette.brandPink }).setOrigin(0.5);
     box.add([bg, silhouettes, copy, spinner]);
-    this.tweens.add({ targets: spinner, angle: 360, duration: 1100, repeat: -1, ease: 'Linear' });
+    if (!prefersReducedMotion()) this.tweens.add({ targets: spinner, angle: 360, duration: motionDuration(1100), repeat: -1, ease: 'Linear' });
     this.emptyState = box;
   }
 
@@ -266,7 +270,8 @@ export abstract class RoomScene extends Phaser.Scene {
     const text = this.add.text(0, 0, 'Reconnecting… changes are safe locally', { fontFamily: typography.families.body, fontSize: '13px', color: cssPalette.plumDeep, fontStyle: 'bold' }).setOrigin(0.5);
     toast.add([bg, text]);
     toast.setAlpha(0);
-    this.tweens.add({ targets: toast, alpha: 1, y: 24, duration: 180 });
+    announce('Disconnected — reconnecting');
+    this.tweens.add({ targets: toast, alpha: 1, y: 24, duration: motionDuration(180) });
     this.reconnectToast = toast;
   }
 
@@ -274,7 +279,8 @@ export abstract class RoomScene extends Phaser.Scene {
     if (!this.reconnectToast) return;
     const toast = this.reconnectToast;
     this.reconnectToast = undefined;
-    this.tweens.add({ targets: toast, alpha: 0, y: 12, duration: 180, onComplete: () => toast.destroy() });
+    announce('Reconnected');
+    this.tweens.add({ targets: toast, alpha: 0, y: 12, duration: motionDuration(180), onComplete: () => toast.destroy() });
   }
 
   private showFallbackToast() {
@@ -311,6 +317,15 @@ export abstract class RoomScene extends Phaser.Scene {
       case 'breed': if (!playSample(this, 'breed')) playBreed(); break;
     }
 
+    const verbs: Record<CareAction, string> = {
+      feed: 'fed',
+      clean: 'bathed',
+      play: 'played with',
+      sleep: 'put to sleep',
+      medicine: 'took to the vet',
+      breed: 'bred',
+    };
+
     const serverActionMap: Partial<Record<CareAction, SaveCareAction>> = { feed: 'feed', clean: 'bathe', play: 'play', sleep: 'sleep', medicine: 'vet' };
     const serverAction = serverActionMap[action];
     let usedLocalFallback = false;
@@ -344,6 +359,7 @@ export abstract class RoomScene extends Phaser.Scene {
     if (boostedStat && bunnyObj) {
       const delta = Math.round(b[boostedStat] - beforeStats[boostedStat]);
       if (delta !== 0) bunnyObj.floatStat(delta, STAT_FLOAT_COLORS[boostedStat]);
+      announce(`${verbs[action][0].toUpperCase()}${verbs[action].slice(1)} ${b.name} — ${boostedStat} now ${Math.round(b[boostedStat])}`);
     }
 
     if ((b.id === 'baby' || b.stage === 'baby') && !isServerBackedBunny(b)) {
@@ -358,19 +374,12 @@ export abstract class RoomScene extends Phaser.Scene {
       writeNeedsState(localNeedsState);
     }
 
-    const verbs: Record<CareAction, string> = {
-      feed: 'fed',
-      clean: 'bathed',
-      play: 'played with',
-      sleep: 'put to sleep',
-      medicine: 'took to the vet',
-      breed: 'bred',
-    };
     addActivity(`${playerName} ${verbs[action]} ${b.name} ${emojis[action] || ''}`);
     wsClient.sendAction(action, bunnyId);
   }
 
   protected playRoomActionFlair(action: CareAction, bunnyObj: Bunny) {
+    if (prefersReducedMotion()) return;
     if (action === 'feed') this.spawnFoodArc(bunnyObj);
     if (action === 'clean') this.spawnBubbleBurst(bunnyObj);
     if (action === 'play') this.spawnToyBounce(bunnyObj);
@@ -385,12 +394,12 @@ export abstract class RoomScene extends Phaser.Scene {
       y: bunny.y - 42,
       angle: 340,
       scale: 0.72,
-      duration: 620,
+      duration: motionDuration(620),
       ease: 'Quad.easeOut',
       onComplete: () => {
         const pop = this.add.text(bunny.x + 8, bunny.y - 66, 'pop!', { fontFamily: typography.families.display, fontSize: '18px', color: cssPalette.plumDeep }).setOrigin(0.5).setDepth(29);
         food.destroy();
-        this.tweens.add({ targets: pop, y: pop.y - 20, alpha: 0, duration: 520, ease: 'Cubic.easeOut', onComplete: () => pop.destroy() });
+        this.tweens.add({ targets: pop, y: pop.y - 20, alpha: 0, duration: motionDuration(520), ease: 'Cubic.easeOut', onComplete: () => pop.destroy() });
       },
     });
   }
@@ -399,22 +408,22 @@ export abstract class RoomScene extends Phaser.Scene {
     for (let i = 0; i < 10; i++) {
       const bubble = this.add.circle(bunny.x + Phaser.Math.Between(-36, 36), bunny.y + Phaser.Math.Between(-20, 36), Phaser.Math.Between(4, 10), palette.sky, 0.42).setDepth(27);
       bubble.setStrokeStyle(1, palette.white, 0.7);
-      this.tweens.add({ targets: bubble, x: bubble.x + Phaser.Math.Between(-24, 24), y: bubble.y - Phaser.Math.Between(34, 76), alpha: 0, scale: 1.35, duration: Phaser.Math.Between(700, 1150), ease: 'Sine.easeOut', onComplete: () => bubble.destroy() });
+      this.tweens.add({ targets: bubble, x: bubble.x + Phaser.Math.Between(-24, 24), y: bubble.y - Phaser.Math.Between(34, 76), alpha: 0, scale: 1.35, duration: motionDuration(Phaser.Math.Between(700, 1150)), ease: 'Sine.easeOut', onComplete: () => bubble.destroy() });
     }
   }
 
   private spawnToyBounce(bunny: Bunny) {
     const ball = this.add.circle(bunny.x - 96, bunny.y + 8, 13, palette.butter, 1).setDepth(28);
     ball.setStrokeStyle(4, palette.brandPink, 0.85);
-    this.tweens.add({ targets: ball, x: bunny.x + 64, y: bunny.y - 46, angle: 720, duration: 760, yoyo: true, ease: 'Sine.easeInOut', onComplete: () => ball.destroy() });
+    this.tweens.add({ targets: ball, x: bunny.x + 64, y: bunny.y - 46, angle: 720, duration: motionDuration(760), yoyo: true, ease: 'Sine.easeInOut', onComplete: () => ball.destroy() });
   }
 
   private spawnVetSparkle(bunny: Bunny) {
     const halo = this.add.circle(bunny.x, bunny.y - 42, 42, palette.success, 0.12).setDepth(27);
     halo.setStrokeStyle(3, palette.success, 0.58);
     const heart = this.add.text(bunny.x, bunny.y - 82, '💚', { fontSize: '28px' }).setOrigin(0.5).setDepth(29);
-    this.tweens.add({ targets: halo, scale: 1.35, alpha: 0, duration: 900, ease: 'Cubic.easeOut', onComplete: () => halo.destroy() });
-    this.tweens.add({ targets: heart, y: heart.y - 34, alpha: 0, duration: 900, ease: 'Cubic.easeOut', onComplete: () => heart.destroy() });
+    this.tweens.add({ targets: halo, scale: 1.35, alpha: 0, duration: motionDuration(900), ease: 'Cubic.easeOut', onComplete: () => halo.destroy() });
+    this.tweens.add({ targets: heart, y: heart.y - 34, alpha: 0, duration: motionDuration(900), ease: 'Cubic.easeOut', onComplete: () => heart.destroy() });
   }
 
   doAction(action: string) {
@@ -437,7 +446,7 @@ export abstract class RoomScene extends Phaser.Scene {
 
     const targetRoom = roomMap[action];
     if (targetRoom && targetRoom !== this.scene.key) {
-      this.cameras.main.fadeOut(250);
+      this.cameras.main.fadeOut(motionDuration(250));
       this.cameras.main.once('camerafadeoutcomplete', () => {
         this.scene.start(targetRoom);
       });
@@ -446,9 +455,27 @@ export abstract class RoomScene extends Phaser.Scene {
       if (bunnyObj && action !== 'breed') {
         bunnyObj.playActionFeedback(action);
         this.playRoomActionFlair(action, bunnyObj);
-        const duration = action === 'sleep' ? 3000 : action === 'feed' || action === 'play' ? 2000 : 1700;
+        const duration = prefersReducedMotion() ? 300 : action === 'sleep' ? 3000 : action === 'feed' || action === 'play' ? 2000 : 1700;
         this.time.delayedCall(duration, () => bunnyObj.startIdleBounce());
       }
     }
+  }
+
+  public selectNextBunny() {
+    const alive = gameBunnies.filter(b => b.isAlive);
+    if (alive.length === 0) return;
+    const current = alive.findIndex(b => b.id === selectedBunnyId);
+    const next = alive[(current + 1 + alive.length) % alive.length];
+    setSelectedBunny(next.id);
+    this.bunnyObjects.forEach(item => item.setSelected(item.bunnyId === selectedBunnyId));
+    announce(`Selected ${next.name}`);
+  }
+
+  public cycleRoom(dir: number) {
+    const idx = ROOM_SEQUENCE.indexOf(this.scene.key);
+    if (idx < 0) return;
+    const next = ROOM_SEQUENCE[(idx + dir + ROOM_SEQUENCE.length) % ROOM_SEQUENCE.length];
+    this.cameras.main.fadeOut(motionDuration(200));
+    this.cameras.main.once('camerafadeoutcomplete', () => this.scene.start(next));
   }
 }

--- a/frontend/src/scenes/VetScene.ts
+++ b/frontend/src/scenes/VetScene.ts
@@ -1,6 +1,7 @@
 import Phaser from 'phaser';
 import { GAME_WIDTH } from '../config';
 import { RoomScene } from './RoomScene';
+import { prefersReducedMotion } from '../utils/accessibility';
 
 const H = 480;
 
@@ -17,8 +18,8 @@ export class VetScene extends RoomScene {
     super.create();
     this.bunnyObjects.forEach(b => {
       b.playMedicine();
-      this.playRoomActionFlair('medicine', b);
-      this.time.delayedCall(2200, () => b.startIdleBounce());
+      if (!prefersReducedMotion()) this.playRoomActionFlair('medicine', b);
+      this.time.delayedCall(prefersReducedMotion() ? 300 : 2200, () => b.startIdleBounce());
     });
   }
 }

--- a/frontend/src/utils/accessibility.ts
+++ b/frontend/src/utils/accessibility.ts
@@ -1,0 +1,17 @@
+export function prefersReducedMotion(): boolean {
+  return typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+export function motionDuration(ms: number): number {
+  return prefersReducedMotion() ? Math.min(ms, 150) : ms;
+}
+
+export function announce(message: string) {
+  if (typeof document === 'undefined') return;
+  const target = document.getElementById('sr-status');
+  if (!target) return;
+  target.textContent = '';
+  window.setTimeout(() => { target.textContent = message; }, 20);
+}


### PR DESCRIPTION
## Summary
- add an off-canvas ARIA live status mirror for selected bunny, room, action, save, and reconnect events
- add keyboard access: Tab cycles bunnies, [/] cycles rooms, 1-6 trigger actions, ? opens shortcut help
- honor reduced-motion preferences by suppressing idle/particle loops and capping transition timings
- strengthen visible focus and text/button contrast for the canvas HUD

## Verification
- npm --prefix frontend run build

Closes #58
Links #47
