### PR TITLE
Redesign login and boot screens

### DIFF
--- a/frontend/assets/branding/login-hero.svg
+++ b/frontend/assets/branding/login-hero.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Bunny Family sunset nest</title>
+  <desc id="desc">A warm sunset scene with two parent bunnies watching over a nest and egg.</desc>
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#ffd0b8"/>
+      <stop offset="0.5" stop-color="#ffe7c7"/>
+      <stop offset="1" stop-color="#f9b4c8"/>
+    </linearGradient>
+    <radialGradient id="sun" cx="50%" cy="45%" r="55%">
+      <stop offset="0" stop-color="#fff3a6" stop-opacity=".95"/>
+      <stop offset="1" stop-color="#ff9fb8" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="8" stdDeviation="8" flood-color="#7b315f" flood-opacity=".22"/>
+    </filter>
+  </defs>
+  <rect width="640" height="360" rx="34" fill="url(#sky)"/>
+  <circle cx="320" cy="130" r="150" fill="url(#sun)"/>
+  <path d="M0 260c80-30 142-25 214 0s142 28 232-2 145-21 194 6v96H0z" fill="#be78a4" opacity=".24"/>
+  <path d="M0 293c92-44 182-18 266-5 98 15 188-31 374 7v65H0z" fill="#7bc9a9" opacity=".45"/>
+  <g opacity=".7" fill="#fff9ef">
+    <ellipse cx="114" cy="83" rx="45" ry="15"/>
+    <ellipse cx="154" cy="79" rx="32" ry="12"/>
+    <ellipse cx="500" cy="86" rx="54" ry="16"/>
+    <ellipse cx="545" cy="82" rx="30" ry="11"/>
+  </g>
+  <g filter="url(#soft)">
+    <g transform="translate(172 144)">
+      <ellipse cx="0" cy="86" rx="46" ry="62" fill="#87c9f5"/>
+      <ellipse cx="0" cy="35" rx="38" ry="34" fill="#87c9f5"/>
+      <ellipse cx="-19" cy="-2" rx="13" ry="45" fill="#87c9f5" transform="rotate(-12 -19 -2)"/>
+      <ellipse cx="17" cy="-6" rx="13" ry="48" fill="#87c9f5" transform="rotate(9 17 -6)"/>
+      <ellipse cx="-19" cy="1" rx="6" ry="30" fill="#ffd4df" transform="rotate(-12 -19 1)"/>
+      <ellipse cx="17" cy="-3" rx="6" ry="31" fill="#ffd4df" transform="rotate(9 17 -3)"/>
+      <circle cx="-13" cy="31" r="4" fill="#452b49"/><circle cx="13" cy="31" r="4" fill="#452b49"/>
+      <path d="M-5 42q5 6 10 0" stroke="#452b49" stroke-width="3" fill="none" stroke-linecap="round"/>
+      <ellipse cx="-24" cy="46" rx="9" ry="5" fill="#ff9fbd" opacity=".55"/><ellipse cx="24" cy="46" rx="9" ry="5" fill="#ff9fbd" opacity=".55"/>
+    </g>
+    <g transform="translate(468 148)">
+      <ellipse cx="0" cy="83" rx="46" ry="60" fill="#d59bed"/>
+      <ellipse cx="0" cy="34" rx="38" ry="34" fill="#d59bed"/>
+      <ellipse cx="-17" cy="-6" rx="13" ry="47" fill="#d59bed" transform="rotate(-7 -17 -6)"/>
+      <ellipse cx="19" cy="-3" rx="13" ry="45" fill="#d59bed" transform="rotate(13 19 -3)"/>
+      <ellipse cx="-17" cy="-3" rx="6" ry="30" fill="#ffd4df" transform="rotate(-7 -17 -3)"/>
+      <ellipse cx="19" cy="0" rx="6" ry="29" fill="#ffd4df" transform="rotate(13 19 0)"/>
+      <circle cx="-13" cy="31" r="4" fill="#452b49"/><circle cx="13" cy="31" r="4" fill="#452b49"/>
+      <path d="M-6 43q6 7 12 0" stroke="#452b49" stroke-width="3" fill="none" stroke-linecap="round"/>
+      <ellipse cx="-24" cy="46" rx="9" ry="5" fill="#ff9fbd" opacity=".55"/><ellipse cx="24" cy="46" rx="9" ry="5" fill="#ff9fbd" opacity=".55"/>
+    </g>
+    <g transform="translate(320 234)">
+      <ellipse cx="0" cy="52" rx="112" ry="34" fill="#8c5a39" opacity=".35"/>
+      <path d="M-118 42c52-54 184-57 236 0-31 42-204 42-236 0z" fill="#b97942"/>
+      <path d="M-98 37c52 24 143 24 196 0" stroke="#6f442b" stroke-width="10" fill="none" stroke-linecap="round"/>
+      <g stroke="#7c4b2e" stroke-width="6" stroke-linecap="round" opacity=".75">
+        <path d="M-100 26l45 38M-64 12l38 58M-20 5l12 68M28 8L5 72M70 15L33 69M103 31L56 66"/>
+      </g>
+      <ellipse cx="0" cy="12" rx="43" ry="58" fill="#fff6df" stroke="#f2b98b" stroke-width="5"/>
+      <path d="M-12 -14c17 8 24 20 8 36 18-4 30 6 28 23" stroke="#ffd06f" stroke-width="5" fill="none" stroke-linecap="round"/>
+    </g>
+  </g>
+  <g fill="#fff7d6" opacity=".9">
+    <circle cx="92" cy="202" r="3"/><circle cx="552" cy="190" r="3"/><circle cx="422" cy="58" r="2.5"/><circle cx="226" cy="74" r="2.5"/>
+  </g>
+</svg>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>🐰 Bunny Family</title>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/frontend/src/scenes/BootScene.ts
+++ b/frontend/src/scenes/BootScene.ts
@@ -4,6 +4,16 @@ import { currentIdentityAssets } from '../state/identityRegistry';
 import { preloadIcons } from '../ui/Icon';
 import { preloadSamples } from '../utils/sampleAudio';
 
+const HERO_KEY = 'login-hero';
+const HERO_PATH = '/assets/branding/login-hero.svg';
+const HINTS = [
+  'Warming up the nest…',
+  'Brushing the bunnies…',
+  'Sweeping the floors…',
+  'Tuning the music…',
+  'Almost there!',
+];
+
 const ROOM_TEXTURES = {
   'room-living': '/assets/rooms/living-room.svg',
   'room-kitchen': '/assets/rooms/kitchen.svg',
@@ -15,65 +25,73 @@ const ROOM_TEXTURES = {
 } as const;
 
 export class BootScene extends Phaser.Scene {
+  private barFill?: Phaser.GameObjects.Rectangle;
+  private statusText?: Phaser.GameObjects.Text;
+
   constructor() { super({ key: 'BootScene' }); }
 
   preload() {
+    this.createLoadingSurface();
+    this.load.svg(HERO_KEY, HERO_PATH, { width: 640, height: 360 });
     preloadIcons(this);
     preloadSamples(this);
     Object.entries(ROOM_TEXTURES).forEach(([key, path]) => {
       this.load.svg(key, path, { width: GAME_WIDTH, height: 480 });
     });
-    // Preload only the persisted selected identities plus index-1 fallbacks.
-    // The full 400-SVG library lives in /assets and is lazy-loaded by scenes
-    // when a new identity/state becomes visible.
     currentIdentityAssets().forEach(({ key, path, kind }) => {
       this.load.svg(key, path, {
         width: kind === 'adult' ? 160 : 120,
         height: kind === 'adult' ? 160 : 120,
       });
     });
+    this.load.on('progress', (pct: number) => this.updateProgress(pct));
+    this.load.on('fileprogress', (_file: Phaser.Loader.File, pct: number) => {
+      const hint = HINTS[Math.min(HINTS.length - 1, Math.floor(pct * HINTS.length))];
+      this.statusText?.setText(hint);
+    });
   }
 
   create() {
+    this.updateProgress(1);
+    this.statusText?.setText('Ready! ✨');
+    this.time.delayedCall(250, () => this.scene.start('LoginScene'));
+  }
+
+  private createLoadingSurface() {
     const cx = GAME_WIDTH / 2;
     const cy = GAME_HEIGHT / 2;
+    this.add.rectangle(cx, cy, GAME_WIDTH, GAME_HEIGHT, 0xffe6c8);
+    this.add.rectangle(cx, 110, GAME_WIDTH, 220, 0xffbed0, 0.38);
+    const cloudA = this.add.ellipse(112, 92, 82, 24, 0xffffff, 0.45);
+    const cloudB = this.add.ellipse(530, 108, 110, 28, 0xffffff, 0.38);
+    this.tweens.add({ targets: cloudA, x: 142, duration: 5200, yoyo: true, repeat: -1, ease: 'Sine.easeInOut' });
+    this.tweens.add({ targets: cloudB, x: 488, duration: 6200, yoyo: true, repeat: -1, ease: 'Sine.easeInOut' });
 
-    this.add.rectangle(cx, cy, GAME_WIDTH, GAME_HEIGHT, 0x1a1a3e);
-
-    this.add.text(cx, cy - 80, '🐰 Bunny Family 🐰', {
+    this.add.text(cx, cy - 122, 'Bunny Family', {
+      fontFamily: 'Fredoka, Nunito, Arial, sans-serif',
+      fontSize: '56px',
+      color: '#f15f9b',
+      shadow: { offsetX: 0, offsetY: 5, color: '#7b315f', blur: 10, fill: true },
+    }).setOrigin(0.5);
+    this.add.text(cx, cy - 78, 'raise your bunny family together', {
       fontFamily: 'Nunito, Arial, sans-serif',
-      fontSize: '28px',
-      color: '#ff6b9d',
-      stroke: '#1a1a3e',
-      strokeThickness: 4,
-      fontStyle: 'bold',
+      fontSize: '14px',
+      color: '#5f315c',
     }).setOrigin(0.5);
 
-    // Modern loading bar
-    this.add.rectangle(cx, cy, 300, 16, 0x333355).setStrokeStyle(2, 0xff6b9d, 0.5);
-    const barFill = this.add.rectangle(cx - 148, cy, 0, 12, 0xff6b9d).setOrigin(0, 0.5);
-
-    const statusText = this.add.text(cx, cy + 25, 'Loading...', {
+    this.add.rectangle(cx, cy + 6, 318, 18, 0xffffff, 0.54).setStrokeStyle(2, 0xf15f9b, 0.55);
+    this.barFill = this.add.rectangle(cx - 155, cy + 6, 0, 12, 0xf15f9b).setOrigin(0, 0.5);
+    this.statusText = this.add.text(cx, cy + 36, HINTS[0], {
       fontFamily: 'Nunito, Arial, sans-serif',
-      fontSize: '12px',
-      color: '#ffffff',
+      fontSize: '13px',
+      color: '#5f315c',
     }).setOrigin(0.5);
+  }
 
-    let progress = 0;
-    this.time.addEvent({
-      delay: 25,
-      repeat: 30,
-      callback: () => {
-        progress += 1 / 30;
-        barFill.width = 296 * Math.min(progress, 1);
-        statusText.setText(`Loading... ${Math.floor(progress * 100)}%`);
-        if (progress >= 1) {
-          statusText.setText('Ready! ✨');
-          this.time.delayedCall(250, () => {
-            this.scene.start('LoginScene');
-          });
-        }
-      },
-    });
+  private updateProgress(pct: number) {
+    const clamped = Phaser.Math.Clamp(pct, 0, 1);
+    if (this.barFill) this.barFill.width = 310 * clamped;
+    const hint = HINTS[Math.min(HINTS.length - 1, Math.floor(clamped * HINTS.length))];
+    this.statusText?.setText(`${hint} ${Math.floor(clamped * 100)}%`);
   }
 }

--- a/frontend/src/scenes/LoginScene.ts
+++ b/frontend/src/scenes/LoginScene.ts
@@ -2,7 +2,13 @@ import Phaser from 'phaser';
 import { GAME_WIDTH, GAME_HEIGHT } from '../config';
 import { wsClient } from '../network/WebSocketClient';
 import { playClick, startBGMusic } from '../utils/sound';
-import { isHatched } from '../state/identityRegistry';
+import { bunnyAssetKey, getIdentities, isHatched } from '../state/identityRegistry';
+
+const PLAYER_KEY_PREFIX = 'bunny-family:last-played:';
+const BRAND_PINK = '#f15f9b';
+const BRAND_PLUM = '#5f315c';
+const CARD_FILL = 0xfffbf1;
+const HERO_KEY = 'login-hero';
 
 export class LoginScene extends Phaser.Scene {
   constructor() { super({ key: 'LoginScene' }); }
@@ -11,124 +17,139 @@ export class LoginScene extends Phaser.Scene {
     const cx = GAME_WIDTH / 2;
     const cy = GAME_HEIGHT / 2;
 
-    // Background gradient
-    this.add.rectangle(cx, cy, GAME_WIDTH, GAME_HEIGHT, 0x1a1a3e);
-    // Subtle gradient overlay
-    this.add.rectangle(cx, cy - 100, GAME_WIDTH, GAME_HEIGHT / 2, 0x2a1a5e, 0.4);
+    this.addWarmBackdrop();
+    this.addHero(cx, cy - 118, 0.7);
+    this.addLogoLockup(cx, cy - 82);
 
-    // Stars
-    for (let i = 0; i < 60; i++) {
-      const sx = Phaser.Math.Between(0, GAME_WIDTH);
-      const sy = Phaser.Math.Between(0, GAME_HEIGHT);
-      const star = this.add.circle(sx, sy, Phaser.Math.Between(1, 3), 0xffffff, Phaser.Math.FloatBetween(0.2, 0.7));
-      this.tweens.add({
-        targets: star,
-        alpha: 0.1,
-        duration: Phaser.Math.Between(800, 2500),
-        yoyo: true,
-        repeat: -1,
-      });
-    }
-
-    // Cute bunny logo - full body
-    const by = cy - 130;
-    // Body
-    this.add.ellipse(cx, by + 15, 45, 50, 0xffb6c1);
-    // Belly
-    this.add.ellipse(cx, by + 22, 28, 30, 0xfff0f5, 0.7);
-    // Head
-    this.add.ellipse(cx, by - 18, 38, 34, 0xffb6c1);
-    // Ears
-    this.add.ellipse(cx - 12, by - 48, 12, 28, 0xffb6c1);
-    this.add.ellipse(cx + 12, by - 48, 12, 28, 0xffb6c1);
-    this.add.ellipse(cx - 12, by - 46, 6, 18, 0xff8fa0);
-    this.add.ellipse(cx + 12, by - 46, 6, 18, 0xff8fa0);
-    // Eyes
-    this.add.ellipse(cx - 8, by - 22, 6, 8, 0x333333);
-    this.add.ellipse(cx + 8, by - 22, 6, 8, 0x333333);
-    this.add.ellipse(cx - 6, by - 24, 2, 2, 0xffffff);
-    this.add.ellipse(cx + 10, by - 24, 2, 2, 0xffffff);
-    // Nose
-    this.add.triangle(cx, by - 14, cx - 3, by - 14, cx + 3, by - 14, cx, by - 11, 0xff8fa0);
-    // Cheeks
-    this.add.ellipse(cx - 16, by - 15, 8, 5, 0xff8fa0, 0.35);
-    this.add.ellipse(cx + 16, by - 15, 8, 5, 0xff8fa0, 0.35);
-    // Arms
-    this.add.ellipse(cx - 22, by + 8, 12, 20, 0xffb6c1);
-    this.add.ellipse(cx + 22, by + 8, 12, 20, 0xffb6c1);
-    // Legs
-    this.add.ellipse(cx - 12, by + 38, 14, 16, 0xffb6c1);
-    this.add.ellipse(cx + 12, by + 38, 14, 16, 0xffb6c1);
-    // Tail
-    this.add.circle(cx - 18, by + 25, 7, 0xfff0f5);
-
-    // Bounce animation on the whole logo area
-    const logoGroup = this.add.rectangle(cx, by, 1, 1, 0x000000, 0);
-    this.tweens.add({ targets: logoGroup, y: by - 8, duration: 1000, yoyo: true, repeat: -1, ease: 'Sine.easeInOut' });
-
-    // Title
-    this.add.text(cx, cy - 40, '🐰 Bunny Family 🐰', {
+    this.add.text(cx, cy + 16, "Who's playing?", {
       fontFamily: 'Nunito, Arial, sans-serif',
-      fontSize: '28px',
-      color: '#ff6b9d',
-      stroke: '#1a1a3e',
-      strokeThickness: 4,
-      fontStyle: 'bold',
+      fontSize: '18px',
+      color: BRAND_PLUM,
+      fontStyle: '700',
     }).setOrigin(0.5);
 
-    this.add.text(cx, cy + 5, "Who's playing?", {
-      fontFamily: 'Nunito, Arial, sans-serif',
-      fontSize: '16px',
-      color: '#ffffff',
-      fontStyle: 'bold',
-    }).setOrigin(0.5);
+    this.createPlayerCard(cx - 122, cy + 92, 'Jonny', 0x42a5f5, bunnyAssetKey('adult', getIdentities().father?.identityIndex ?? 1));
+    this.createPlayerCard(cx + 122, cy + 92, 'Elina', 0xce93d8, bunnyAssetKey('adult', getIdentities().mother?.identityIndex ?? 2));
+    this.createAddPlayerCard(cx, cy + 218);
+  }
 
-    // Modern player buttons
-    this.createPlayerButton(cx - 100, cy + 60, '💙 Jonny', 0x42a5f5, 'Jonny');
-    this.createPlayerButton(cx + 100, cy + 60, '💜 Elina', 0xce93d8, 'Elina');
-
-    this.add.text(cx, cy + 120, 'Take care of your bunnies together!', {
-      fontFamily: 'Nunito, Arial, sans-serif',
-      fontSize: '12px',
-      color: '#ffffff',
-    }).setOrigin(0.5).setAlpha(0.5);
-
-    // Decorative sparkles at bottom
-    for (let i = 0; i < 8; i++) {
-      const sp = this.add.text(Phaser.Math.Between(50, GAME_WIDTH - 50), Phaser.Math.Between(GAME_HEIGHT - 100, GAME_HEIGHT - 20), '✨', { fontSize: '10px' }).setAlpha(0.2);
-      this.tweens.add({ targets: sp, alpha: 0.05, duration: 2000, yoyo: true, repeat: -1, delay: i * 250 });
+  private addWarmBackdrop() {
+    this.add.rectangle(GAME_WIDTH / 2, GAME_HEIGHT / 2, GAME_WIDTH, GAME_HEIGHT, 0xffe6c8);
+    this.add.rectangle(GAME_WIDTH / 2, 115, GAME_WIDTH, 230, 0xffbed0, 0.42);
+    this.add.circle(120, 80, 90, 0xfff0a6, 0.2);
+    for (let i = 0; i < 10; i += 1) {
+      const x = Phaser.Math.Between(24, GAME_WIDTH - 24);
+      const y = Phaser.Math.Between(440, GAME_HEIGHT - 16);
+      const sparkle = this.add.text(x, y, '✦', { fontSize: `${Phaser.Math.Between(8, 14)}px`, color: '#ffffff' }).setAlpha(0.3);
+      this.tweens.add({ targets: sparkle, y: y - 8, alpha: 0.1, duration: 1800 + i * 120, yoyo: true, repeat: -1 });
     }
   }
 
-  private createPlayerButton(x: number, y: number, text: string, color: number, name: string) {
-    const btn = this.add.rectangle(x, y, 160, 48, color, 0.9)
-      .setStrokeStyle(2, 0xffffff, 0.3)
-      .setInteractive({ useHandCursor: true });
+  private addHero(x: number, y: number, scale: number) {
+    const hero = this.add.image(x, y, HERO_KEY).setDisplaySize(440 * scale, 248 * scale).setAlpha(0.98);
+    this.tweens.add({ targets: hero, y: y - 5, duration: 2600, yoyo: true, repeat: -1, ease: 'Sine.easeInOut' });
+  }
 
-    this.add.text(x, y, text, {
-      fontFamily: 'Nunito, Arial, sans-serif',
-      fontSize: '16px',
-      color: '#ffffff',
-      stroke: '#00000033',
-      strokeThickness: 1,
-      fontStyle: 'bold',
+  private addLogoLockup(x: number, y: number) {
+    this.add.text(x, y, 'Bunny Family', {
+      fontFamily: 'Fredoka, Nunito, Arial, sans-serif',
+      fontSize: '56px',
+      color: BRAND_PINK,
+      shadow: { offsetX: 0, offsetY: 5, color: '#7b315f', blur: 10, fill: true },
     }).setOrigin(0.5);
+    this.add.text(x, y + 44, 'raise your bunny family together', {
+      fontFamily: 'Nunito, Arial, sans-serif',
+      fontSize: '14px',
+      color: BRAND_PLUM,
+    }).setOrigin(0.5);
+  }
 
-    btn.on('pointerover', () => btn.setScale(1.08));
-    btn.on('pointerout', () => btn.setScale(1));
-    btn.on('pointerdown', async () => {
-      playClick();
-      startBGMusic();
-      this.registry.set('playerName', name);
-      await wsClient.connect(name);
-      // First-run / mid-hatch users see the onboarding nest. Once the baby
-      // has hatched the save persists, so returning users land in the rooms.
-      if (isHatched()) {
-        this.scene.start('LivingRoomScene');
-        this.scene.launch('HUDScene');
-      } else {
-        this.scene.start('OnboardingNestScene');
-      }
+  private createPlayerCard(x: number, y: number, name: string, accent: number, fallbackTexture: string) {
+    const group = this.add.container(x, y);
+    const shadow = this.add.rectangle(0, 8, 220, 120, 0x7b315f, 0.14).setOrigin(0.5).setScale(1, 0.98);
+    const card = this.add.rectangle(0, 0, 220, 120, CARD_FILL, 0.96)
+      .setStrokeStyle(3, accent, 0.34)
+      .setInteractive(new Phaser.Geom.Rectangle(-110, -60, 220, 120), Phaser.Geom.Rectangle.Contains)
+      .setData('role', 'button');
+    const avatarRing = this.add.circle(-58, -6, 35, accent, 0.16).setStrokeStyle(2, accent, 0.4);
+    const avatar = this.textures.exists(fallbackTexture)
+      ? this.add.image(-58, -8, fallbackTexture).setDisplaySize(58, 58)
+      : this.add.text(-58, -8, name === 'Jonny' ? '💙' : '💜', { fontSize: '34px' }).setOrigin(0.5);
+
+    const title = this.add.text(-6, -24, name, {
+      fontFamily: 'Fredoka, Nunito, Arial, sans-serif',
+      fontSize: '28px',
+      color: BRAND_PLUM,
+    }).setOrigin(0, 0.5);
+    const sub = this.add.text(-6, 7, this.lastPlayedLabel(name), {
+      fontFamily: 'Nunito, Arial, sans-serif',
+      fontSize: '13px',
+      color: '#8a557d',
+    }).setOrigin(0, 0.5);
+    const cta = this.add.text(-6, 32, 'tap to continue', {
+      fontFamily: 'Nunito, Arial, sans-serif',
+      fontSize: '12px',
+      color: '#a86c91',
+      fontStyle: '700',
+    }).setOrigin(0, 0.5);
+
+    group.add([shadow, card, avatarRing, avatar, title, sub, cta]);
+    card.on('pointerover', () => group.setScale(1.035));
+    card.on('pointerout', () => group.setScale(1));
+    card.on('pointerdown', () => this.selectPlayer(group, name));
+  }
+
+  private createAddPlayerCard(x: number, y: number) {
+    const group = this.add.container(x, y);
+    const card = this.add.rectangle(0, 0, 220, 70, 0xffffff, 0.42)
+      .setStrokeStyle(2, 0xffffff, 0.85)
+      .setInteractive(new Phaser.Geom.Rectangle(-110, -35, 220, 70), Phaser.Geom.Rectangle.Contains);
+    const plus = this.add.text(-72, 0, '+', { fontFamily: 'Fredoka, Nunito, Arial, sans-serif', fontSize: '38px', color: BRAND_PLUM }).setOrigin(0.5);
+    const copy = this.add.text(-42, 0, 'Add player\ncoming soon', { fontFamily: 'Nunito, Arial, sans-serif', fontSize: '14px', color: BRAND_PLUM }).setOrigin(0, 0.5);
+    group.add([card, plus, copy]);
+    card.on('pointerdown', () => this.toast('Add player is coming soon ✨'));
+  }
+
+  private lastPlayedLabel(name: string): string {
+    const raw = localStorage.getItem(`${PLAYER_KEY_PREFIX}${name}`);
+    const last = raw ? Number(raw) : 0;
+    if (!last || !Number.isFinite(last)) return 'new player';
+    const hours = Math.max(1, Math.floor((Date.now() - last) / 36e5));
+    if (hours < 24) return `last played ${hours}h ago`;
+    return `last played ${Math.floor(hours / 24)}d ago`;
+  }
+
+  private selectPlayer(group: Phaser.GameObjects.Container, name: string) {
+    playClick();
+    startBGMusic();
+    localStorage.setItem(`${PLAYER_KEY_PREFIX}${name}`, String(Date.now()));
+    this.registry.set('playerName', name);
+    this.tweens.add({
+      targets: group,
+      scale: 0.96,
+      alpha: 0,
+      duration: 200,
+      ease: 'Quad.easeOut',
+      onComplete: async () => {
+        await wsClient.connect(name);
+        if (isHatched()) {
+          this.scene.start('LivingRoomScene');
+          this.scene.launch('HUDScene');
+        } else {
+          this.scene.start('OnboardingNestScene');
+        }
+      },
     });
+  }
+
+  private toast(message: string) {
+    const toast = this.add.text(GAME_WIDTH / 2, GAME_HEIGHT - 36, message, {
+      fontFamily: 'Nunito, Arial, sans-serif',
+      fontSize: '14px',
+      color: '#ffffff',
+      backgroundColor: '#5f315ccc',
+      padding: { x: 14, y: 8 },
+    }).setOrigin(0.5).setDepth(20);
+    this.tweens.add({ targets: toast, y: toast.y - 10, alpha: 0, delay: 900, duration: 450, onComplete: () => toast.destroy() });
   }
 }


### PR DESCRIPTION
## Summary
- Replaced placeholder login logo with a branded warm hero SVG family/nest scene.
- Added Fredoka/Nunito logo lockup, tagline, 220x120 player cards with avatar, last-played subtext, press-in fade transition, and inert add-player card toast.
- Reworked BootScene to use the same brand lockup, real Phaser loader progress, rotating loading hints, and soft cloud drift.
- Removed mobile viewport zoom blocking from index.html.

## Verification
- npm --prefix frontend run build

## Notes
- Hero SVG is 4.1 KB, under the 120 KB limit.
- Mobile 360x800 QA and screenshots still need browser/live validation after deploy.

Closes #54
Links #47