### PR TITLE
Add mobile-first responsive layout

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,17 +6,23 @@
   <title>🐰 Bunny Family</title>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
-    body {
+    html, body {
+      width: 100%;
+      height: 100%;
       background: #1a1a3e;
+    }
+    body {
       display: flex;
       justify-content: center;
       align-items: center;
       min-height: 100vh;
+      min-height: 100dvh;
       overflow: hidden;
+      padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
       font-family: Arial, sans-serif;
     }
-    #game-container { position: relative; }
-    canvas { display: block; }
+    #game-container { position: relative; width: 100vw; height: 100dvh; overflow: hidden; }
+    canvas { display: block; width: 100%; height: 100%; touch-action: manipulation; }
     .sr-only {
       position: absolute;
       width: 1px;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -19,8 +19,10 @@ const config: Phaser.Types.Core.GameConfig = {
   parent: 'game-container',
   backgroundColor: COLORS.bg,
   scale: {
-    mode: Phaser.Scale.FIT,
+    mode: Phaser.Scale.RESIZE,
     autoCenter: Phaser.Scale.CENTER_BOTH,
+    min: { width: 320, height: 520 },
+    max: { width: 1280, height: 900 },
   },
   scene: [
     BootScene,

--- a/frontend/src/objects/Bunny.ts
+++ b/frontend/src/objects/Bunny.ts
@@ -600,8 +600,9 @@ export class Bunny extends Phaser.GameObjects.Container {
   setDraggable(onSelect: () => void, onMove?: (x: number, y: number) => void) {
     const s = this.getStageScale();
     // Container-level hit area covers head + body so the whole bunny is grabbable.
-    const hitW = 80 * s;
-    const hitH = 130 * s;
+    const mobile = this.scene.scale.width < 700;
+    const hitW = Math.max(mobile ? 100 : 80, 80 * s);
+    const hitH = Math.max(mobile ? 150 : 130, 130 * s);
     this.setSize(hitW, hitH);
     this.setInteractive(new Phaser.Geom.Rectangle(-hitW / 2, -65 * s, hitW, hitH), Phaser.Geom.Rectangle.Contains);
     (this.scene.input as Phaser.Input.InputPlugin).setDraggable(this);

--- a/frontend/src/scenes/BathroomScene.ts
+++ b/frontend/src/scenes/BathroomScene.ts
@@ -1,16 +1,17 @@
 import Phaser from 'phaser';
-import { GAME_WIDTH } from '../config';
+import { getLayout } from '../ui/layout';
 import { RoomScene } from './RoomScene';
 import { prefersReducedMotion } from '../utils/accessibility';
 
-const H = 480;
 
 export class BathroomScene extends RoomScene {
   constructor() { super({ key: 'BathroomScene' }); }
   getRoomName() { return '🛁 Bathroom'; }
 
   drawRoom() {
-    this.add.image(GAME_WIDTH / 2, H / 2, 'room-bathroom').setDisplaySize(GAME_WIDTH, H);
+    const layout = getLayout(this);
+    const H = layout.playBottom;
+    this.add.image(layout.width / 2, H / 2, 'room-bathroom').setDisplaySize(layout.width, H);
   }
 
 

--- a/frontend/src/scenes/BedroomScene.ts
+++ b/frontend/src/scenes/BedroomScene.ts
@@ -1,16 +1,17 @@
 import Phaser from 'phaser';
-import { GAME_WIDTH } from '../config';
+import { getLayout } from '../ui/layout';
 import { RoomScene } from './RoomScene';
 import { prefersReducedMotion } from '../utils/accessibility';
 
-const H = 480;
 
 export class BedroomScene extends RoomScene {
   constructor() { super({ key: 'BedroomScene' }); }
   getRoomName() { return '🌙 Bedroom'; }
 
   drawRoom() {
-    this.add.image(GAME_WIDTH / 2, H / 2, 'room-bedroom').setDisplaySize(GAME_WIDTH, H);
+    const layout = getLayout(this);
+    const H = layout.playBottom;
+    this.add.image(layout.width / 2, H / 2, 'room-bedroom').setDisplaySize(layout.width, H);
   }
 
   create() {

--- a/frontend/src/scenes/GardenScene.ts
+++ b/frontend/src/scenes/GardenScene.ts
@@ -1,16 +1,17 @@
 import Phaser from 'phaser';
-import { GAME_WIDTH } from '../config';
+import { getLayout } from '../ui/layout';
 import { RoomScene } from './RoomScene';
 import { prefersReducedMotion } from '../utils/accessibility';
 
-const H = 480;
 
 export class GardenScene extends RoomScene {
   constructor() { super({ key: 'GardenScene' }); }
   getRoomName() { return '🌿 Garden'; }
 
   drawRoom() {
-    this.add.image(GAME_WIDTH / 2, H / 2, 'room-garden').setDisplaySize(GAME_WIDTH, H);
+    const layout = getLayout(this);
+    const H = layout.playBottom;
+    this.add.image(layout.width / 2, H / 2, 'room-garden').setDisplaySize(layout.width, H);
   }
 
   create() {

--- a/frontend/src/scenes/HUDScene.ts
+++ b/frontend/src/scenes/HUDScene.ts
@@ -8,6 +8,7 @@ import { ACTION_COOLDOWNS, CARE_ACTIONS, type CareAction } from '../game/actions
 import { addIcon, type IconName } from '../ui/Icon';
 import { cssPalette, palette, typography } from '../ui/tokens';
 import { announce, motionDuration } from '../utils/accessibility';
+import { getLayout } from '../ui/layout';
 
 const HUD_PREF_KEY = 'bunny:hud-expanded';
 const SIDE_PANEL_WIDTH = 184;
@@ -36,6 +37,9 @@ export class HUDScene extends Phaser.Scene {
   private helpPanel?: Phaser.GameObjects.Container;
   private focusOutline?: Phaser.GameObjects.Rectangle;
   private focusedButton = 0;
+  private dock!: Phaser.GameObjects.Container;
+  private dockBg!: Phaser.GameObjects.Graphics;
+  private dockItems: Array<{ hit: Phaser.GameObjects.Rectangle; icon: Phaser.GameObjects.Image; text: Phaser.GameObjects.Text; dot: Phaser.GameObjects.Text; index: number }> = [];
 
   constructor() { super({ key: 'HUDScene' }); }
 
@@ -48,7 +52,7 @@ export class HUDScene extends Phaser.Scene {
     this.createRoomLabel();
     this.installKeyboardShortcuts();
 
-    this.scale.on('resize', () => this.layoutPanel());
+    this.scale.on('resize', () => { this.layoutPanel(); this.layoutDock(); this.layoutRoomLabel(); });
 
     this.time.addEvent({
       delay: 400,
@@ -164,10 +168,11 @@ export class HUDScene extends Phaser.Scene {
 
   private layoutPanel() {
     this.isMobile = this.scale.width < MOBILE_BREAKPOINT;
+    const layout = getLayout(this);
     const width = this.hudExpanded ? SIDE_PANEL_WIDTH : COMPACT_PANEL_WIDTH;
-    const height = this.hudExpanded ? PLAY_AREA_HEIGHT - 24 : 116;
-    const x = GAME_WIDTH - width - SIDE_PANEL_MARGIN;
-    const y = this.isMobile && !this.hudExpanded ? SIDE_PANEL_MARGIN + 38 : SIDE_PANEL_MARGIN;
+    const height = this.hudExpanded ? Math.min(PLAY_AREA_HEIGHT - 24, layout.hudMaxHeight) : 116;
+    const x = layout.hudX - width;
+    const y = this.isMobile && !this.hudExpanded ? layout.hudY + 38 : layout.hudY;
 
     this.panel.setPosition(x, y);
     this.drawPanelBg(width, height);
@@ -193,17 +198,9 @@ export class HUDScene extends Phaser.Scene {
 
   private createNavigation() {
     const rooms = ['LivingRoomScene', 'KitchenScene', 'BathroomScene', 'GardenScene', 'BedroomScene', 'VetScene', 'NestScene'];
-    const dock = this.add.container(GAME_WIDTH / 2, PLAY_AREA_HEIGHT - 28).setDepth(45);
-    const shadow = this.add.graphics();
-    shadow.fillStyle(palette.plumDeep, 0.16);
-    shadow.fillRoundedRect(-191, -21, 382, 54, 18);
-    dock.add(shadow);
-    const bg = this.add.graphics();
-    bg.fillStyle(palette.cream, 0.92);
-    bg.fillRoundedRect(-191, -27, 382, 54, 18);
-    bg.lineStyle(1, palette.white, 0.7);
-    bg.strokeRoundedRect(-190, -26, 380, 52, 17);
-    dock.add(bg);
+    this.dock = this.add.container(0, 0).setDepth(45);
+    this.dockBg = this.add.graphics();
+    this.dock.add(this.dockBg);
 
     const icons: Array<{ room: string; icon: IconName; label: string; need?: string }> = [
       { room: 'LivingRoomScene', icon: 'play', label: 'Home', need: 'happiness' },
@@ -238,7 +235,32 @@ export class HUDScene extends Phaser.Scene {
       hit.on('pointerover', () => icon.setScale(1.14));
       hit.on('pointerout', () => icon.setScale(1));
       hit.on('pointerdown', () => this.startRoom(item.room, rooms));
-      dock.add([hit, icon, text, dot]);
+      this.dock.add([hit, icon, text, dot]);
+      this.dockItems.push({ hit, icon, text, dot, index });
+    });
+    this.layoutDock();
+  }
+
+  private layoutDock() {
+    if (!this.dock || !this.dockBg) return;
+    const layout = getLayout(this);
+    const spacing = layout.orientation === 'portrait' ? Math.min(60, (layout.width - layout.safeLeft - layout.safeRight - 32) / 7) : 55;
+    const width = spacing * 7 + 10;
+    this.dock.setPosition(layout.width / 2, layout.dockY);
+    this.dockBg.clear();
+    this.dockBg.fillStyle(palette.plumDeep, 0.16);
+    this.dockBg.fillRoundedRect(-width / 2, -27, width, 62, 20);
+    this.dockBg.fillStyle(palette.cream, 0.92);
+    this.dockBg.fillRoundedRect(-width / 2, -32, width, 62, 20);
+    this.dockBg.lineStyle(1, palette.white, 0.7);
+    this.dockBg.strokeRoundedRect(-width / 2 + 1, -31, width - 2, 60, 19);
+    this.dockItems.forEach(({ hit, icon, text, dot, index }) => {
+      const x = -spacing * 3 + index * spacing;
+      hit.setPosition(x, -2).setSize(layout.dockIconSize, layout.dockIconSize);
+      hit.input!.hitArea = new Phaser.Geom.Rectangle(-layout.dockIconSize / 2, -layout.dockIconSize / 2, layout.dockIconSize, layout.dockIconSize);
+      icon.setPosition(x, -8).setDisplaySize(26, 26);
+      text.setPosition(x, 18);
+      dot.setPosition(x + 15, -25);
     });
   }
 
@@ -251,6 +273,13 @@ export class HUDScene extends Phaser.Scene {
       strokeThickness: 3,
       fontStyle: 'bold',
     }).setOrigin(0.5).setDepth(40);
+    this.layoutRoomLabel();
+  }
+
+  private layoutRoomLabel() {
+    if (!this.roomLabel) return;
+    const layout = getLayout(this);
+    this.roomLabel.setPosition(layout.width / 2, layout.safeTop + 12);
   }
 
   private updateHUD() {

--- a/frontend/src/scenes/KitchenScene.ts
+++ b/frontend/src/scenes/KitchenScene.ts
@@ -1,16 +1,17 @@
 import Phaser from 'phaser';
-import { GAME_WIDTH } from '../config';
+import { getLayout } from '../ui/layout';
 import { RoomScene } from './RoomScene';
 import { prefersReducedMotion } from '../utils/accessibility';
 
-const H = 480;
 
 export class KitchenScene extends RoomScene {
   constructor() { super({ key: 'KitchenScene' }); }
   getRoomName() { return '🍳 Kitchen'; }
 
   drawRoom() {
-    this.add.image(GAME_WIDTH / 2, H / 2, 'room-kitchen').setDisplaySize(GAME_WIDTH, H);
+    const layout = getLayout(this);
+    const H = layout.playBottom;
+    this.add.image(layout.width / 2, H / 2, 'room-kitchen').setDisplaySize(layout.width, H);
   }
 
   create() {

--- a/frontend/src/scenes/LivingRoomScene.ts
+++ b/frontend/src/scenes/LivingRoomScene.ts
@@ -1,9 +1,8 @@
 import Phaser from 'phaser';
-import { GAME_WIDTH } from '../config';
+import { getLayout } from '../ui/layout';
 import { RoomScene } from './RoomScene';
 import { motionDuration, prefersReducedMotion } from '../utils/accessibility';
 
-const H = 480; // play area height
 
 export class LivingRoomScene extends RoomScene {
   private enterWithCurtainWipe = false;
@@ -16,16 +15,20 @@ export class LivingRoomScene extends RoomScene {
   getRoomName() { return '🏠 Living Room'; }
 
   drawRoom() {
-    this.add.image(GAME_WIDTH / 2, H / 2, 'room-living').setDisplaySize(GAME_WIDTH, H);
+    const layout = getLayout(this);
+    const H = layout.playBottom;
+    this.add.image(layout.width / 2, H / 2, 'room-living').setDisplaySize(layout.width, H);
     if (this.enterWithCurtainWipe && !prefersReducedMotion()) this.playCurtainOpen();
   }
 
   private playCurtainOpen() {
-    const curtain = this.add.rectangle(GAME_WIDTH / 2, H / 2, GAME_WIDTH, H, 0xff7eaa, 1).setDepth(100);
+    const layout = getLayout(this);
+    const H = layout.playBottom;
+    const curtain = this.add.rectangle(layout.width / 2, H / 2, layout.width, H, 0xff7eaa, 1).setDepth(100);
     const glint = this.add.rectangle(12, H / 2, 22, H, 0xffb3cc, 0.75).setDepth(101);
     this.tweens.add({
       targets: [curtain, glint],
-      x: GAME_WIDTH + GAME_WIDTH / 2,
+      x: layout.width + layout.width / 2,
       duration: motionDuration(420),
       ease: 'Sine.easeInOut',
       onComplete: () => curtain.destroy(),

--- a/frontend/src/scenes/NestScene.ts
+++ b/frontend/src/scenes/NestScene.ts
@@ -1,15 +1,16 @@
 import Phaser from 'phaser';
-import { GAME_WIDTH } from '../config';
+import { getLayout } from '../ui/layout';
 import { RoomScene } from './RoomScene';
 
-const H = 480;
 
 export class NestScene extends RoomScene {
   constructor() { super({ key: 'NestScene' }); }
   getRoomName() { return '💕 Cozy Nest'; }
 
   drawRoom() {
-    this.add.image(GAME_WIDTH / 2, H / 2, 'room-nest').setDisplaySize(GAME_WIDTH, H);
+    const layout = getLayout(this);
+    const H = layout.playBottom;
+    this.add.image(layout.width / 2, H / 2, 'room-nest').setDisplaySize(layout.width, H);
   }
 
 }

--- a/frontend/src/scenes/RoomScene.ts
+++ b/frontend/src/scenes/RoomScene.ts
@@ -12,9 +12,12 @@ import { playBreed, playClean, playFeed, playMedicine, playPlay, playSleep } fro
 import { playSample } from '../utils/sampleAudio';
 import { needColors, palette, typography, cssPalette } from '../ui/tokens';
 import { announce, motionDuration, prefersReducedMotion } from '../utils/accessibility';
+import { getLayout, type LayoutContext } from '../ui/layout';
 
-const PLAY_AREA_HEIGHT = 480; // Game area above toolbar
-const MOVE_BOUNDS = { minX: 60, maxX: GAME_WIDTH - 60, minY: 120, maxY: PLAY_AREA_HEIGHT - 60 };
+const PLAY_AREA_HEIGHT = 480; // Design baseline; runtime layout may resize it.
+function moveBounds(layout: LayoutContext) {
+  return { minX: 60, maxX: layout.width - 60, minY: Math.max(100, layout.playTop + 70), maxY: layout.playBottom - 60 };
+}
 const ARROW_STEP = 14;
 const ROOM_SEQUENCE = ['LivingRoomScene', 'KitchenScene', 'BathroomScene', 'GardenScene', 'BedroomScene', 'VetScene', 'NestScene'];
 
@@ -113,13 +116,14 @@ export abstract class RoomScene extends Phaser.Scene {
 
     // Day/night overlay (only over play area)
     const tint = getDayNightTint();
-    this.dayNightOverlay = this.add.rectangle(GAME_WIDTH / 2, PLAY_AREA_HEIGHT / 2, GAME_WIDTH, PLAY_AREA_HEIGHT, tint.color, tint.alpha);
+    const layout = getLayout(this);
+    this.dayNightOverlay = this.add.rectangle(layout.width / 2, layout.playBottom / 2, layout.width, layout.playBottom, tint.color, tint.alpha);
     this.dayNightOverlay.setDepth(5);
 
     // Season indicator
     const season = getSeason();
     const seasonEmojis: Record<string, string> = { spring: '🌸', summer: '☀️', autumn: '🍂', winter: '❄️' };
-    this.add.text(GAME_WIDTH - 40, 8, seasonEmojis[season] || '', {
+    this.add.text(layout.width - 40, layout.safeTop + 8, seasonEmojis[season] || '', {
       fontSize: '20px',
     }).setDepth(6);
 
@@ -180,8 +184,9 @@ export abstract class RoomScene extends Phaser.Scene {
     if (c?.down?.isDown || w?.S?.isDown) dy += ARROW_STEP;
     if (dx === 0 && dy === 0) return;
     target.moveBy(dx, dy);
-    target.x = Phaser.Math.Clamp(target.x, MOVE_BOUNDS.minX, MOVE_BOUNDS.maxX);
-    target.y = Phaser.Math.Clamp(target.y, MOVE_BOUNDS.minY, MOVE_BOUNDS.maxY);
+    const bounds = moveBounds(getLayout(this));
+    target.x = Phaser.Math.Clamp(target.x, bounds.minX, bounds.maxX);
+    target.y = Phaser.Math.Clamp(target.y, bounds.minY, bounds.maxY);
   }
 
   protected spawnBunnies() {
@@ -189,8 +194,9 @@ export abstract class RoomScene extends Phaser.Scene {
     this.bunnyObjects = [];
 
     const alive = gameBunnies.filter(b => b.isAlive);
-    const groundY = PLAY_AREA_HEIGHT - 80;
-    const spacing = (GAME_WIDTH - 100) / (alive.length + 1);
+    const layout = getLayout(this);
+    const groundY = layout.playBottom - 80;
+    const spacing = (layout.width - 100) / (alive.length + 1);
 
     const identities = getIdentities();
     const identityById: Record<string, CharacterIdentity | null> = {
@@ -215,8 +221,9 @@ export abstract class RoomScene extends Phaser.Scene {
         this.scene.get('HUDScene')?.events.emit('bunnySelected', b.id);
       };
       bunny.setDraggable(select, (x, y) => {
-        bunny.x = Phaser.Math.Clamp(x, MOVE_BOUNDS.minX, MOVE_BOUNDS.maxX);
-        bunny.y = Phaser.Math.Clamp(y, MOVE_BOUNDS.minY, MOVE_BOUNDS.maxY);
+        const bounds = moveBounds(getLayout(this));
+        bunny.x = Phaser.Math.Clamp(x, bounds.minX, bounds.maxX);
+        bunny.y = Phaser.Math.Clamp(y, bounds.minY, bounds.maxY);
       });
       this.bunnyObjects.push(bunny);
     });
@@ -236,7 +243,8 @@ export abstract class RoomScene extends Phaser.Scene {
 
   private showEmptyState() {
     if (this.emptyState) return;
-    const box = this.add.container(GAME_WIDTH / 2, 238).setDepth(32);
+    const layout = getLayout(this);
+    const box = this.add.container(layout.width / 2, Math.min(238, layout.playBottom / 2)).setDepth(32);
     const bg = this.add.graphics();
     bg.fillStyle(palette.cream, 0.92);
     bg.fillRoundedRect(-180, -82, 360, 164, 22);
@@ -265,8 +273,9 @@ export abstract class RoomScene extends Phaser.Scene {
 
   private showReconnectToast() {
     if (this.reconnectToast) return;
-    const toast = this.add.container(GAME_WIDTH / 2, 18).setDepth(80);
-    const bg = this.add.rectangle(0, 0, GAME_WIDTH - 80, 28, palette.butter, 0.92).setStrokeStyle(1, palette.plumDeep, 0.18);
+    const layout = getLayout(this);
+    const toast = this.add.container(layout.width / 2, layout.safeTop + 18).setDepth(80);
+    const bg = this.add.rectangle(0, 0, layout.width - 80, 28, palette.butter, 0.92).setStrokeStyle(1, palette.plumDeep, 0.18);
     const text = this.add.text(0, 0, 'Reconnecting… changes are safe locally', { fontFamily: typography.families.body, fontSize: '13px', color: cssPalette.plumDeep, fontStyle: 'bold' }).setOrigin(0.5);
     toast.add([bg, text]);
     toast.setAlpha(0);
@@ -285,7 +294,8 @@ export abstract class RoomScene extends Phaser.Scene {
 
   private showFallbackToast() {
     if (this.fallbackToast) this.fallbackToast.destroy();
-    const toast = this.add.container(GAME_WIDTH / 2, PLAY_AREA_HEIGHT - 84).setDepth(82);
+    const layout = getLayout(this);
+    const toast = this.add.container(layout.width / 2, layout.playBottom - 84).setDepth(82);
     const bg = this.add.rectangle(0, 0, 330, 34, palette.plumDeep, 0.86);
     const text = this.add.text(0, 0, 'Saved locally — syncing when connected', { fontFamily: typography.families.body, fontSize: '13px', color: cssPalette.white, fontStyle: 'bold' }).setOrigin(0.5);
     toast.add([bg, text]);

--- a/frontend/src/scenes/VetScene.ts
+++ b/frontend/src/scenes/VetScene.ts
@@ -1,16 +1,17 @@
 import Phaser from 'phaser';
-import { GAME_WIDTH } from '../config';
+import { getLayout } from '../ui/layout';
 import { RoomScene } from './RoomScene';
 import { prefersReducedMotion } from '../utils/accessibility';
 
-const H = 480;
 
 export class VetScene extends RoomScene {
   constructor() { super({ key: 'VetScene' }); }
   getRoomName() { return '💊 Vet Office'; }
 
   drawRoom() {
-    this.add.image(GAME_WIDTH / 2, H / 2, 'room-vet').setDisplaySize(GAME_WIDTH, H);
+    const layout = getLayout(this);
+    const H = layout.playBottom;
+    this.add.image(layout.width / 2, H / 2, 'room-vet').setDisplaySize(layout.width, H);
   }
 
 

--- a/frontend/src/ui/layout.ts
+++ b/frontend/src/ui/layout.ts
@@ -1,0 +1,64 @@
+import Phaser from 'phaser';
+import { GAME_WIDTH, GAME_HEIGHT } from '../config';
+
+export type Orientation = 'portrait' | 'landscape';
+
+export interface LayoutContext {
+  width: number;
+  height: number;
+  orientation: Orientation;
+  safeTop: number;
+  safeRight: number;
+  safeBottom: number;
+  safeLeft: number;
+  playTop: number;
+  playBottom: number;
+  dockY: number;
+  dockIconSize: number;
+  hudX: number;
+  hudY: number;
+  hudMaxHeight: number;
+  roomScaleX: number;
+  roomScaleY: number;
+}
+
+
+export function getLayout(scene: Phaser.Scene): LayoutContext {
+  const width = scene.scale.width || GAME_WIDTH;
+  const height = scene.scale.height || GAME_HEIGHT;
+  const orientation: Orientation = height > width ? 'portrait' : 'landscape';
+  const style = typeof window !== 'undefined' ? getComputedStyle(document.body) : null;
+  const safeTop = style ? Number.parseFloat(style.paddingTop) || 0 : 0;
+  const safeRight = style ? Number.parseFloat(style.paddingRight) || 0 : 0;
+  const safeBottom = style ? Number.parseFloat(style.paddingBottom) || 0 : 0;
+  const safeLeft = style ? Number.parseFloat(style.paddingLeft) || 0 : 0;
+  const dockIconSize = orientation === 'portrait' ? 56 : 50;
+  const dockY = height - safeBottom - (orientation === 'portrait' ? 42 : 34);
+  const playTop = safeTop;
+  const playBottom = Math.max(playTop + 260, dockY - (orientation === 'portrait' ? 78 : 58));
+  return {
+    width,
+    height,
+    orientation,
+    safeTop,
+    safeRight,
+    safeBottom,
+    safeLeft,
+    playTop,
+    playBottom,
+    dockY,
+    dockIconSize,
+    hudX: width - safeRight - 12,
+    hudY: safeTop + 12,
+    hudMaxHeight: Math.max(180, playBottom - playTop - 8),
+    roomScaleX: width / GAME_WIDTH,
+    roomScaleY: playBottom / 480,
+  };
+}
+
+export function onLayout(scene: Phaser.Scene, callback: (layout: LayoutContext) => void) {
+  const apply = () => callback(getLayout(scene));
+  apply();
+  scene.scale.on('resize', apply);
+  scene.events.once(Phaser.Scenes.Events.SHUTDOWN, () => scene.scale.off('resize', apply));
+}


### PR DESCRIPTION
## Summary
- Switched Phaser scaling from FIT to RESIZE with viewport min/max bounds.
- Added a layout context helper for orientation, viewport size, safe-area padding, play area, dock, and HUD anchors.
- Anchored room backgrounds, HUD panel, room label, reconnect/local-save toasts, and room dock to the live viewport instead of fixed 800x600 coordinates.
- Increased mobile dock tap areas to 56px and mobile bunny drag hitboxes to at least 100x150.
- Added iOS safe-area padding and full-viewport canvas styling while leaving pinch zoom enabled.

## Verification
- npm --prefix frontend run build

## Notes
- Wide 1280 room art remains deferred as requested.
- Browser recording/mobile rotation QA still needs live validation after deploy.

Closes #55
Links #47